### PR TITLE
feat: 그룹 탈퇴 기능 구현 

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/SecessionGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/SecessionGroupController.java
@@ -1,0 +1,27 @@
+package foot.footprint.domain.group.api;
+
+import foot.footprint.domain.group.application.SecessionGroupService;
+import foot.footprint.global.security.user.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/groups")
+@RequiredArgsConstructor
+public class SecessionGroupController {
+
+  private final SecessionGroupService secessionGroupService;
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> sessionGroup(@PathVariable("id") Long groupId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    secessionGroupService.secessionGroup(groupId, userDetails.getId());
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/SecessionGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/SecessionGroupService.java
@@ -1,0 +1,37 @@
+package foot.footprint.domain.group.application;
+
+import foot.footprint.domain.group.dao.GroupRepository;
+import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.global.error.exception.NotExistsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SecessionGroupService {
+
+  private final GroupRepository groupRepository;
+
+  private final MemberGroupRepository memberGroupRepository;
+
+  @Transactional
+  public void secessionGroup(Long groupId, Long memberId) {
+    deleteMemberGroup(groupId, memberId);
+    deleteGroupIfMemberIsNotExist(groupId);
+  }
+
+  private void deleteMemberGroup(Long groupId, Long memberId) {
+    int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
+    if (deleted == 0) {
+      throw new NotExistsException("이미 탈퇴한 그룹이거나 존재하지 않는 그룹입니다.");
+    }
+  }
+
+  private void deleteGroupIfMemberIsNotExist(Long groupId) {
+    Long memberCount = memberGroupRepository.countMemberGroup(groupId);
+    if (memberCount <= 0) {
+      groupRepository.deleteById(groupId);
+    }
+  }
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
@@ -2,6 +2,7 @@ package foot.footprint.domain.group.dao;
 
 import foot.footprint.domain.group.domain.Group;
 import java.util.Optional;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
@@ -19,4 +20,7 @@ public interface GroupRepository {
 
   @Update("UPDATE group_table SET invitation_code=#{invitation_code} WHERE id=#{id}")
   int updateInvitationCode(Group group);
+
+  @Delete("DELETE FROM group_table WHERE id=#{groupId}")
+  int deleteById(Long groupId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.group.dao;
 
 import foot.footprint.domain.group.domain.MemberGroup;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
@@ -9,4 +10,7 @@ public interface MemberGroupRepository {
   Long saveMemberGroup(MemberGroup memberGroup);
 
   boolean checkAlreadyJoined(Long groupId, Long memberId);
+
+  @Delete("DELETE FROM member_group WHERE group_id=#{groupId} and member_id=#{memberId}")
+  int deleteMemberGroup(Long groupId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.group.dao;
 import foot.footprint.domain.group.domain.MemberGroup;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface MemberGroupRepository {
@@ -13,4 +14,7 @@ public interface MemberGroupRepository {
 
   @Delete("DELETE FROM member_group WHERE group_id=#{groupId} and member_id=#{memberId}")
   int deleteMemberGroup(Long groupId, Long memberId);
+
+  @Select("SELECT COUNT(*) FROM member_group WHERE group_id=#{groupId}")
+  Long countMemberGroup(Long groupId);
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
@@ -69,4 +69,22 @@ public class GroupRepositoryTest extends RepositoryTest {
     assertThat(foundGroup).isPresent();
     assertThat(anotherGroup).isNotPresent();
   }
+
+  @Test
+  public void deleteById() {
+    //given
+    String invitationCode = "testCode";
+    Group group = Group.builder()
+        .create_date(new Date())
+        .name("test_group")
+        .invitation_code(invitationCode)
+        .owner_id(1L).build();
+    groupRepository.saveGroup(group);
+
+    //when & then
+    assertThat(groupRepository.findById(group.getId())).isPresent();
+    int result = groupRepository.deleteById(group.getId());
+    assertThat(groupRepository.findById(group.getId())).isNotPresent();
+    assertThat(result).isEqualTo(1);
+  }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
@@ -84,7 +84,9 @@ public class GroupRepositoryTest extends RepositoryTest {
     //when & then
     assertThat(groupRepository.findById(group.getId())).isPresent();
     int result = groupRepository.deleteById(group.getId());
+    int dummy = groupRepository.deleteById(200L);
     assertThat(groupRepository.findById(group.getId())).isNotPresent();
     assertThat(result).isEqualTo(1);
+    assertThat(dummy).isEqualTo(0);
   }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -53,7 +53,6 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
     Group group = buildGroup(member.getId());
     groupRepository.saveGroup(group);
     MemberGroup memberGroup =  buildMemberGroup(group.getId(), member.getId());
-    assertThat(memberGroup.getId()).isNull();
     memberGroupRepository.saveMemberGroup(memberGroup);
 
     //when
@@ -63,6 +62,28 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
     //then
     assertThat(result).isTrue();
     assertThat(result2).isFalse();
+  }
+
+  @Test
+  public void deleteMemberGroup() {
+    //given
+    Member member = buildMember();
+    memberRepository.saveMember(member);
+    Group group = buildGroup(member.getId());
+    groupRepository.saveGroup(group);
+    MemberGroup memberGroup =  buildMemberGroup(group.getId(), member.getId());
+    memberGroupRepository.saveMemberGroup(memberGroup);
+
+
+    //when
+    boolean result1 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
+    int deleted = memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
+    boolean result2 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
+
+    //then
+    assertThat(result1).isEqualTo(true);
+    assertThat(deleted).isEqualTo(1);
+    assertThat(result2).isEqualTo(false);
   }
 
   private Group buildGroup(Long ownerId) {

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -79,11 +79,13 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
     boolean result1 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
     int deleted = memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
     boolean result2 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
+    int dummyDeleted = memberGroupRepository.deleteMemberGroup(group.getId(), 1000L);
 
     //then
     assertThat(result1).isEqualTo(true);
     assertThat(deleted).isEqualTo(1);
     assertThat(result2).isEqualTo(false);
+    assertThat(dummyDeleted).isEqualTo(0);
   }
 
   @Test

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -86,6 +86,31 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
     assertThat(result2).isEqualTo(false);
   }
 
+  @Test
+  public void countMemberGroup() {
+    //given
+    Member member = buildMember();
+    Member member2 = buildMember();
+    memberRepository.saveMember(member);
+    memberRepository.saveMember(member2);
+    Group group = buildGroup(member.getId());
+    groupRepository.saveGroup(group);
+    MemberGroup memberGroup =  buildMemberGroup(group.getId(), member.getId());
+    memberGroupRepository.saveMemberGroup(memberGroup);
+    MemberGroup memberGroup2 =  buildMemberGroup(group.getId(), member2.getId());
+    memberGroupRepository.saveMemberGroup(memberGroup2);
+
+    //when
+    Long count = memberGroupRepository.countMemberGroup(group.getId());
+    memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
+    memberGroupRepository.deleteMemberGroup(group.getId(), member2.getId());
+    Long count2 = memberGroupRepository.countMemberGroup(group.getId());
+
+    //then
+    assertThat(count).isEqualTo(2);
+    assertThat(count2).isEqualTo(0);
+  }
+
   private Group buildGroup(Long ownerId) {
     return Group.builder()
         .create_date(new Date())

--- a/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
@@ -1,0 +1,79 @@
+package foot.footprint.service.group;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import foot.footprint.domain.group.application.SecessionGroupService;
+import foot.footprint.domain.group.dao.GroupRepository;
+import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.global.error.exception.NotExistsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SecessionGroupServiceTest {
+
+  @Spy
+  private GroupRepository groupRepository;
+
+  @Mock
+  private MemberGroupRepository memberGroupRepository;
+
+  @InjectMocks
+  private SecessionGroupService secessionGroupService;
+
+  @Test
+  @DisplayName("그룹 탈퇴 - 그룹 삭제 x")
+  public void secessionGroup() {
+    //given
+    given(memberGroupRepository.deleteMemberGroup(any(), any()))
+        .willReturn(1);
+    given(memberGroupRepository.countMemberGroup(any()))
+        .willReturn(1L);
+
+    //when
+    secessionGroupService.secessionGroup(1L, 1L);
+
+    //then
+    verify(groupRepository, times(0)).deleteById(any());
+  }
+
+  @Test
+  @DisplayName("그룹 탈퇴 - 해당하는 그룹이 없거나 가입이 안되어있을 때")
+  public void secessionGroup_IfNotExistsGroup() {
+    //given
+    given(memberGroupRepository.deleteMemberGroup(any(), any()))
+        .willReturn(0);
+
+    //when & then
+    assertThatThrownBy(
+        () -> secessionGroupService.secessionGroup(1L, 1L))
+        .isInstanceOf(NotExistsException.class);
+  }
+
+  @Test
+  @DisplayName("그룹 탈퇴 - 탈퇴 후 그룹에 남은 인원이 없을 시")
+  public void secessionGroup_IfMemberIsNotExists() {
+    //given
+    given(memberGroupRepository.deleteMemberGroup(any(), any()))
+        .willReturn(1);
+    given(memberGroupRepository.countMemberGroup(any()))
+        .willReturn(0L);
+    given(groupRepository.deleteById(any()))
+        .willReturn(any());
+
+    //when
+    secessionGroupService.secessionGroup(1L, 1L);
+
+    //then
+    verify(groupRepository, times(1)).deleteById(any());
+  }
+}


### PR DESCRIPTION

resolved: #35 

그룹 탈퇴기능을 구현하였다.
1. Repository 내의 3개의 메서드 구현(MemberGroup 삭제, Count, Group 삭제) 구현 및 테스트
2. Service 구현 및 테스트
3. Controller 구현 및 테스트

자세한 사항은 노션 참고