### PR TITLE
feat: 그룹 상세 조회 페이지 구현

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetailsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetailsDto.java
@@ -1,6 +1,6 @@
 package foot.footprint.domain.article.dto;
 
-import foot.footprint.domain.comment.dto.AuthorDto;
+import foot.footprint.global.domain.AuthorDto;
 import java.util.Date;
 import lombok.Getter;
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/CreateCommentService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/CreateCommentService.java
@@ -4,7 +4,7 @@ import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.comment.dao.CreateCommentRepository;
 import foot.footprint.domain.comment.domain.Comment;
-import foot.footprint.domain.comment.dto.AuthorDto;
+import foot.footprint.global.domain.AuthorDto;
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.domain.member.dao.MemberRepository;

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.comment.dto;
 
 import foot.footprint.domain.comment.domain.Comment;
+import foot.footprint.global.domain.AuthorDto;
 import java.util.Date;
 import lombok.Getter;
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/FindGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/FindGroupController.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.group.api;
 
 import foot.footprint.domain.group.application.FindGroupService;
+import foot.footprint.domain.group.dto.GroupDetailsResponse;
 import foot.footprint.domain.group.dto.GroupSummaryResponse;
 import foot.footprint.global.security.user.CustomUserDetails;
 import java.util.List;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,9 +32,16 @@ public class FindGroupController {
   @GetMapping("/mine")
   public ResponseEntity<List<GroupSummaryResponse>> findMyGroups(
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    List<GroupSummaryResponse> responses = findGroupService.findMyGroups(
-        userDetails.getId());
+    List<GroupSummaryResponse> responses = findGroupService.findMyGroups(userDetails.getId());
 
     return ResponseEntity.ok().body(responses);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<GroupDetailsResponse> findOne(@PathVariable("id") Long groupId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    GroupDetailsResponse response = findGroupService.findOne(groupId, userDetails.getId());
+
+    return ResponseEntity.ok().body(response);
   }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/JoinGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/JoinGroupController.java
@@ -18,7 +18,7 @@ public class JoinGroupController {
 
   private final JoinGroupService joinGroupService;
 
-  @PostMapping("/join")
+  @PostMapping("/admission")
   public ResponseEntity<Void> join(@RequestParam(value = "invitation_code") String invitationCode,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     Long groupId = joinGroupService.join(invitationCode, userDetails.getId());

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/FindGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/FindGroupService.java
@@ -1,7 +1,10 @@
 package foot.footprint.domain.group.application;
 
+import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.domain.group.dto.GroupDetailsResponse;
 import foot.footprint.domain.group.dto.GroupSummaryResponse;
+import foot.footprint.global.error.exception.NotAuthorizedOrExistException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +16,8 @@ public class FindGroupService {
 
   private final MemberGroupRepository memberGroupRepository;
 
+  private final GroupRepository groupRepository;
+
   @Transactional(readOnly = true)
   public List<GroupSummaryResponse> findMyImportantGroups(Long memberId) {
     return memberGroupRepository.findMyImportantGroups(memberId);
@@ -20,5 +25,11 @@ public class FindGroupService {
 
   public List<GroupSummaryResponse> findMyGroups(Long memberId) {
     return memberGroupRepository.findMyGroups(memberId);
+  }
+
+  public GroupDetailsResponse findOne(Long groupId, Long memberId) {
+    GroupDetailsResponse response = groupRepository.findGroupDetails(groupId, memberId)
+        .orElseThrow(() -> new NotAuthorizedOrExistException("그룹을 조회할 권한이 없습니다."));
+    return response;
   }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.group.dao;
 
 import foot.footprint.domain.group.domain.Group;
+import foot.footprint.domain.group.dto.GroupDetailsResponse;
 import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Delete;
@@ -28,4 +29,6 @@ public interface GroupRepository {
   int deleteById(Long groupId);
 
   List<Long> findAllByMemberId(Long memberId);
+
+  Optional<GroupDetailsResponse> findGroupDetails(Long groupId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupDetailsResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupDetailsResponse.java
@@ -1,0 +1,20 @@
+package foot.footprint.domain.group.dto;
+
+import java.util.Date;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupDetailsResponse {
+
+  private Long id;
+  private String name;
+  private String invitationCode;
+  private Boolean important;
+  private Date createDate;
+  private List<MemberDto> memberDetails;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/MemberDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/MemberDto.java
@@ -1,0 +1,14 @@
+package foot.footprint.domain.group.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberDto {
+  private Long id;
+  private String nickName;
+  private String imageUrl;
+}

--- a/backend/footprint/src/main/java/foot/footprint/global/domain/AuthorDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/domain/AuthorDto.java
@@ -1,4 +1,4 @@
-package foot.footprint.domain.comment.dto;
+package foot.footprint.global.domain;
 
 import foot.footprint.domain.member.domain.Member;
 import lombok.Getter;

--- a/backend/footprint/src/main/resources/mapper/group/GroupMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/group/GroupMapper.xml
@@ -15,4 +15,26 @@
     UPDATE group_table SET name = #{newName}
     WHERE id = #{groupId} and owner_id =#{ownerId}
   </update>
+  <select id="findGroupDetails" resultMap="groupDetails">
+    SELECT g.id groupId, g.name AS name, g.invitation_code invitationCode,
+    (SELECT important FROM member_group WHERE group_id = #{groupId} and member_id = #{memberId}) AS important,
+    g.create_date createDate
+    ,m.id AS memberId, m.nick_name AS nickName, m.image_url AS imageUrl
+    FROM group_table g LEFT JOIN member_group mg ON g.id = mg.group_id
+    LEFT JOIN member m ON mg.member_id = m.id
+    WHERE g.id = #{groupId}
+    AND #{memberId} IN (SELECT member_id FROM member_group WHERE group_id = #{groupId})
+  </select>
+  <resultMap id="groupDetails" type="GroupDetailsResponse">
+    <id property="id" column="groupId"/>
+    <result property="name" column="name"/>
+    <result property="invitationCode" column="invitationCode"/>
+    <result property="important" column="important"/>
+    <result property="createDate" column="createDate"/>
+    <collection property="memberDetails" ofType="foot.footprint.domain.group.dto.MemberDto">
+      <id property="id" column="memberId"/>
+      <result property="nickName" column="nickName"/>
+      <result property="imageUrl" column="imageUrl"/>
+    </collection>
+  </resultMap>
 </mapper>

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
@@ -6,6 +6,7 @@ import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
 import foot.footprint.domain.group.domain.Group;
 import foot.footprint.domain.group.domain.MemberGroup;
+import foot.footprint.domain.group.dto.GroupDetailsResponse;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.repository.RepositoryTest;
@@ -29,11 +30,8 @@ public class GroupRepositoryTest extends RepositoryTest {
   @Test
   public void saveGroup() {
     //given
-    Group group = Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .invitation_code("testCode")
-        .owner_id(1L).build();
+    Group group = Group.builder().create_date(new Date()).name("test_group")
+        .invitation_code("testCode").owner_id(1L).build();
 
     //when & then
     assertThat(group.getId()).isNull();
@@ -46,10 +44,7 @@ public class GroupRepositoryTest extends RepositoryTest {
   @Test
   public void updateInvitationCode() {
     //given
-    Group group = Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .owner_id(1L).build();
+    Group group = Group.builder().create_date(new Date()).name("test_group").owner_id(1L).build();
 
     //when & then
     assertThat(group.getId()).isNull();
@@ -66,11 +61,8 @@ public class GroupRepositoryTest extends RepositoryTest {
     //given
     String invitationCode = "testCode";
     String anotherCode = "testOrCode";
-    Group group = Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .invitation_code(invitationCode)
-        .owner_id(1L).build();
+    Group group = Group.builder().create_date(new Date()).name("test_group")
+        .invitation_code(invitationCode).owner_id(1L).build();
     groupRepository.saveGroup(group);
 
     //when
@@ -85,11 +77,8 @@ public class GroupRepositoryTest extends RepositoryTest {
   public void deleteById() {
     //given
     String invitationCode = "testCode";
-    Group group = Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .invitation_code(invitationCode)
-        .owner_id(1L).build();
+    Group group = Group.builder().create_date(new Date()).name("test_group")
+        .invitation_code(invitationCode).owner_id(1L).build();
     groupRepository.saveGroup(group);
 
     //when & then
@@ -143,11 +132,44 @@ public class GroupRepositoryTest extends RepositoryTest {
     assertThat(editedGroup.getName()).isEqualTo(newName);
   }
 
+  @Test
+  public void findGroupDetails() {
+    //given
+    Member member1 = buildMember();
+    memberRepository.saveMember(member1);
+    Member member2 = buildMember();
+    memberRepository.saveMember(member2);
+    Member member3 = buildMember();
+    memberRepository.saveMember(member3);
+    Group group = buildGroup(member1.getId());
+    groupRepository.saveGroup(group);
+    MemberGroup memberGroup1 = MemberGroup.createMemberGroup(group.getId(), member1.getId());
+    MemberGroup memberGroup2 = MemberGroup.createMemberGroup(group.getId(), member2.getId());
+    MemberGroup memberGroup3 = MemberGroup.createMemberGroup(group.getId(), member3.getId());
+    memberGroup2.changeImportant();
+    memberGroupRepository.saveMemberGroup(memberGroup1);
+    memberGroupRepository.saveMemberGroup(memberGroup2);
+    memberGroupRepository.saveMemberGroup(memberGroup3);
+
+    //when & then
+    Optional<GroupDetailsResponse> response1 = groupRepository.findGroupDetails(2L,
+        member1.getId());
+    assertThat(response1.isPresent()).isFalse();
+    Optional<GroupDetailsResponse> response2 = groupRepository.findGroupDetails(group.getId(), 32L);
+    assertThat(response2.isPresent()).isFalse();
+    Optional<GroupDetailsResponse> response3 = groupRepository.findGroupDetails(group.getId(),
+        member1.getId());
+    assertThat(response3.get().getMemberDetails()).hasSize(3);
+    assertThat(response3.get().getImportant()).isFalse();
+    Optional<GroupDetailsResponse> response4 = groupRepository.findGroupDetails(group.getId(),
+        member2.getId());
+    assertThat(response4.get().getMemberDetails()).hasSize(3);
+    assertThat(response4.get().getImportant()).isTrue();
+    assertThat(response4.get().getId()).isEqualTo(group.getId());
+  }
+
   private Group buildGroup(Long ownerId, String invitationCode) {
-    return Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .invitation_code(invitationCode)
-        .owner_id(ownerId).build();
+    return Group.builder().create_date(new Date()).name("test_group")
+        .invitation_code(invitationCode).owner_id(ownerId).build();
   }
 }


### PR DESCRIPTION
resolved: #57 
그룹 상세 조회 페이지를 구현하였다.
그룹 정보 및 그룹원들의 정보를 리턴하며 db는 1회 접근한다. 
resultMap을 통해 jpa에 eagerJoin처럼 1회의 db접근만을 하도록 구현하였다. 

참고 사이트: 
argument type mismatch
https://stackoverflow.com/questions/16774448/mybatis-and-invalid-types
https://velog.io/@jkh9615/Kotlinspring-boot%EC%97%90%EC%84%9C-MyBatis-Collection-ResultMap

연속 left join
https://kimsyoung.tistory.com/entry/3%EA%B0%9C-%EC%9D%B4%EC%83%81%EC%9D%98-%ED%85%8C%EC%9D%B4%EB%B8%94-LEFT-JOIN-%ED%95%98%EA%B8%B0

exists and in
https://codingspooning.tistory.com/entry/MySQL-EXISTS%EC%99%80-IN-%EC%82%AC%EC%9A%A9%EB%B2%95-%EB%B9%84%EA%B5%90%ED%95%98%EA%B8%B0-%EC%98%88%EC%A0%9C

subQuery
https://snowple.tistory.com/360

resultMap#collection
https://mybatis.org/mybatis-3/ko/sqlmap-xml.html#Parameters
https://velog.io/@hanblueblue/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B82-3.-Join%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-%ED%95%9C-%EB%B2%88%EC%97%90-%EC%97%B0%EA%B4%80%EA%B0%9D%EC%B2%B4-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0