### PR TITLE
feat: 마이페이지 찾기 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.26/8f8cf0372abf564913e9796623aac4c8ea44025a/lombok-1.18.26.jar" />
+        </processorPath>
+        <module name="backend.footprint.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/footprint.iml
+++ b/.idea/footprint.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/backend/footprint" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/backend/footprint" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.footprint.main.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.footprint.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/footprint.iml" filepath="$PROJECT_DIR$/.idea/footprint.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/backend.footprint.main.iml
+++ b/.idea/modules/backend.footprint.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../backend/footprint/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../backend/footprint/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/backend/.idea/modules.xml
+++ b/backend/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/backend.iml" filepath="$PROJECT_DIR$/.idea/backend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/footprint.main.iml" filepath="$PROJECT_DIR$/.idea/modules/footprint.main.iml" />
     </modules>
   </component>
 </project>

--- a/backend/.idea/modules/footprint.main.iml
+++ b/backend/.idea/modules/footprint.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../footprint/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../footprint/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/backend/footprint/src/main/java/foot/footprint/FootprintApplication.java
+++ b/backend/footprint/src/main/java/foot/footprint/FootprintApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class FootprintApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(FootprintApplication.class, args);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(FootprintApplication.class, args);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/api/CreateArticleController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/api/CreateArticleController.java
@@ -21,31 +21,31 @@ import java.net.URI;
 @RequestMapping("/articles")
 public class CreateArticleController {
 
-  private final CreateArticleService createArticleService;
+    private final CreateArticleService createArticleService;
 
-  @PostMapping("/create")
-  public ResponseEntity<Void> create(@RequestBody @Valid CreateArticleRequest request,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    validateLocation(request.getLatitude(), request.getLongitude());
-    Long articleId = createArticleService.create(request, userDetails.getId());
+    @PostMapping("/create")
+    public ResponseEntity<Void> create(@RequestBody @Valid CreateArticleRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateLocation(request.getLatitude(), request.getLongitude());
+        Long articleId = createArticleService.create(request, userDetails.getId());
 
-    if (request.isPublicMap()) {
-      return buildArticleCreateResponse("/articles/public/" + articleId);
+        if (request.isPublicMap()) {
+            return buildArticleCreateResponse("/articles/public/" + articleId);
+        }
+        if (request.isPrivateMap()) {
+            return buildArticleCreateResponse("/articles/private/" + articleId);
+        }
+        return buildArticleCreateResponse("/articles/grouped/" + articleId);
     }
-    if (request.isPrivateMap()) {
-      return buildArticleCreateResponse("/articles/private/" + articleId);
-    }
-    return buildArticleCreateResponse("/articles/grouped/" + articleId);
-  }
 
-  private void validateLocation(double lat, double lng) {
-    if (lat >= 180 || lat <= -180 || lng >= 180 || lng <= -180) {
-      throw new WrongInputException("위치 좌표가 범위를 넘었습니다.");
+    private void validateLocation(double lat, double lng) {
+        if (lat >= 180 || lat <= -180 || lng >= 180 || lng <= -180) {
+            throw new WrongInputException("위치 좌표가 범위를 넘었습니다.");
+        }
     }
-  }
 
-  private ResponseEntity<Void> buildArticleCreateResponse(String uri) {
-    return ResponseEntity.created(URI.create(uri))
-        .build();
-  }
+    private ResponseEntity<Void> buildArticleCreateResponse(String uri) {
+        return ResponseEntity.created(URI.create(uri))
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/api/DeleteArticleController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/api/DeleteArticleController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DeleteArticleController {
 
-  private final DeleteArticleService deleteArticleService;
+    private final DeleteArticleService deleteArticleService;
 
-  @DeleteMapping("/{articleId}")
-  public ResponseEntity<Void> deleteArticle(@PathVariable Long articleId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    deleteArticleService.delete(articleId, userDetails.getId());
+    @DeleteMapping("/{articleId}")
+    public ResponseEntity<Void> deleteArticle(@PathVariable Long articleId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        deleteArticleService.delete(articleId, userDetails.getId());
 
-    return ResponseEntity.noContent()
-        .build();
-  }
+        return ResponseEntity.noContent()
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/api/EditArticleController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/api/EditArticleController.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class EditArticleController {
 
-  private final EditArticleService editArticleService;
+    private final EditArticleService editArticleService;
 
-  @PutMapping("/{articleId}")
-  public ResponseEntity<Void> editArticle(@PathVariable("articleId") Long articleId,
-      @RequestBody EditArticleContentRequest request,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    editArticleService.edit(articleId, userDetails.getId(), request.getNewContent());
-    return ResponseEntity.noContent()
-        .build();
-  }
+    @PutMapping("/{articleId}")
+    public ResponseEntity<Void> editArticle(@PathVariable("articleId") Long articleId,
+        @RequestBody EditArticleContentRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        editArticleService.edit(articleId, userDetails.getId(), request.getNewContent());
+        return ResponseEntity.noContent()
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/api/FindArticleController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/api/FindArticleController.java
@@ -23,54 +23,55 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FindArticleController {
 
-  private final FindArticleService findArticleService;
+    private final FindArticleService findArticleService;
 
-  private final FindArticleDetailsService findArticleDetailsService;
+    private final FindArticleDetailsService findArticleDetailsService;
 
-  @GetMapping("/public")
-  public ResponseEntity<List<ArticleMapResponse>> findPublicMapArticles(
-      ArticleRangeRequest request) {
-    validateLocation(request);
-    LocationRange locationRange = new LocationRange(request);
-    List<ArticleMapResponse> publicMapArticles = findArticleService.findPublicMapArticles(
-        locationRange);
-    return ResponseEntity.ok().body(publicMapArticles);
-  }
-
-  @GetMapping("/private")
-  public ResponseEntity<List<ArticleMapResponse>> findPrivateMapArticles(
-      ArticleRangeRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
-    validateLocation(request);
-    LocationRange locationRange = new LocationRange(request);
-    List<ArticleMapResponse> privateMapArticles = findArticleService.findPrivateMapArticles(
-        userDetails.getId(), locationRange);
-    return ResponseEntity.ok().body(privateMapArticles);
-  }
-
-  @GetMapping("/grouped")
-  public ResponseEntity<List<ArticleMapResponse>> findGroupedMapArticles(
-      @RequestParam(value = "groupId") Long groupId, ArticleRangeRequest request,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    validateLocation(request);
-    LocationRange locationRange = new LocationRange(request);
-    List<ArticleMapResponse> groupedMapArticles = findArticleService.findGroupedArticles(
-        userDetails.getId(), groupId, locationRange);
-    return ResponseEntity.ok().body(groupedMapArticles);
-  }
-
-  private void validateLocation(ArticleRangeRequest request) {
-    if (request.getLatitude() >= 180 || request.getLatitude() <= -180
-        || request.getLongitude() >= 180 || request.getLongitude() <= -180) {
-      throw new WrongInputException("위치 좌표가 범위를 넘었습니다.");
+    @GetMapping("/public")
+    public ResponseEntity<List<ArticleMapResponse>> findPublicMapArticles(
+        ArticleRangeRequest request) {
+        validateLocation(request);
+        LocationRange locationRange = new LocationRange(request);
+        List<ArticleMapResponse> publicMapArticles = findArticleService.findPublicMapArticles(
+            locationRange);
+        return ResponseEntity.ok().body(publicMapArticles);
     }
-  }
 
-  @GetMapping("/details/{articleId}")
-  public ResponseEntity<ArticlePageResponse> findArticleDetails(
-      @PathVariable("articleId") Long articleId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    ArticlePageResponse response = findArticleDetailsService.findDetails(articleId, userDetails);
+    @GetMapping("/private")
+    public ResponseEntity<List<ArticleMapResponse>> findPrivateMapArticles(
+        ArticleRangeRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateLocation(request);
+        LocationRange locationRange = new LocationRange(request);
+        List<ArticleMapResponse> privateMapArticles = findArticleService.findPrivateMapArticles(
+            userDetails.getId(), locationRange);
+        return ResponseEntity.ok().body(privateMapArticles);
+    }
 
-    return ResponseEntity.ok().body(response);
-  }
+    @GetMapping("/grouped")
+    public ResponseEntity<List<ArticleMapResponse>> findGroupedMapArticles(
+        @RequestParam(value = "groupId") Long groupId, ArticleRangeRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateLocation(request);
+        LocationRange locationRange = new LocationRange(request);
+        List<ArticleMapResponse> groupedMapArticles = findArticleService.findGroupedArticles(
+            userDetails.getId(), groupId, locationRange);
+        return ResponseEntity.ok().body(groupedMapArticles);
+    }
+
+    private void validateLocation(ArticleRangeRequest request) {
+        if (request.getLatitude() >= 180 || request.getLatitude() <= -180
+            || request.getLongitude() >= 180 || request.getLongitude() <= -180) {
+            throw new WrongInputException("위치 좌표가 범위를 넘었습니다.");
+        }
+    }
+
+    @GetMapping("/details/{articleId}")
+    public ResponseEntity<ArticlePageResponse> findArticleDetails(
+        @PathVariable("articleId") Long articleId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        ArticlePageResponse response = findArticleDetailsService.findDetails(articleId,
+            userDetails);
+
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/CreateArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/CreateArticleService.java
@@ -18,49 +18,49 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class CreateArticleService {
 
-  private final CreateArticleRepository articleRepository;
+    private final CreateArticleRepository articleRepository;
 
-  private final ArticleGroupRepository articleGroupRepository;
+    private final ArticleGroupRepository articleGroupRepository;
 
-  private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository;
 
-  @Transactional
-  public Long create(CreateArticleRequest request, Long memberId) {
-    Article article = Article.createArticle(request, memberId);
-    validateMapType(request);
-    articleRepository.saveArticle(article);
-    if (!request.getGroupIdsToBeIncluded().isEmpty()) {
-      articleGroupRepository.saveArticleGroupList(
-          createArticleGroupList(request, article.getId(), memberId));
+    @Transactional
+    public Long create(CreateArticleRequest request, Long memberId) {
+        Article article = Article.createArticle(request, memberId);
+        validateMapType(request);
+        articleRepository.saveArticle(article);
+        if (!request.getGroupIdsToBeIncluded().isEmpty()) {
+            articleGroupRepository.saveArticleGroupList(
+                createArticleGroupList(request, article.getId(), memberId));
+        }
+        return article.getId();
     }
-    return article.getId();
-  }
 
-  private void validateMapType(CreateArticleRequest request) {
-    List<Long> groups = request.getGroupIdsToBeIncluded();
-    if (!request.isPublicMap() && !request.isPrivateMap()
-        && (Objects.isNull(groups) || groups.isEmpty())) {
-      throw new NotIncludedMapException("전체지도, 그룹지도, 개인지도 중 하나는 포함해야합니다.");
+    private void validateMapType(CreateArticleRequest request) {
+        List<Long> groups = request.getGroupIdsToBeIncluded();
+        if (!request.isPublicMap() && !request.isPrivateMap()
+            && (Objects.isNull(groups) || groups.isEmpty())) {
+            throw new NotIncludedMapException("전체지도, 그룹지도, 개인지도 중 하나는 포함해야합니다.");
+        }
     }
-  }
 
-  private List<ArticleGroup> createArticleGroupList(CreateArticleRequest request, Long articleId,
-      Long memberId) {
-    List<Long> groupIds = request.getGroupIdsToBeIncluded();
-    checkAreMyGroups(groupIds, memberId);
-    List<ArticleGroup> articleGroupList = new ArrayList<>();
-    for (Long groupId : groupIds) {
-      articleGroupList.add(ArticleGroup.createArticleGroup(groupId, articleId));
+    private List<ArticleGroup> createArticleGroupList(CreateArticleRequest request, Long articleId,
+        Long memberId) {
+        List<Long> groupIds = request.getGroupIdsToBeIncluded();
+        checkAreMyGroups(groupIds, memberId);
+        List<ArticleGroup> articleGroupList = new ArrayList<>();
+        for (Long groupId : groupIds) {
+            articleGroupList.add(ArticleGroup.createArticleGroup(groupId, articleId));
+        }
+        return articleGroupList;
     }
-    return articleGroupList;
-  }
 
-  private void checkAreMyGroups(List<Long> groupIds, Long memberId) {
-    List<Long> myGroupIds = groupRepository.findAllByMemberId(memberId);
-    for (Long groupId : groupIds) {
-      if (!myGroupIds.contains(groupId)) {
-        throw new NotIncludedMapException("그룹 목록에 가입되어있지 않는 그룹이 포함되어 있습니다.");
-      }
+    private void checkAreMyGroups(List<Long> groupIds, Long memberId) {
+        List<Long> myGroupIds = groupRepository.findAllByMemberId(memberId);
+        for (Long groupId : groupIds) {
+            if (!myGroupIds.contains(groupId)) {
+                throw new NotIncludedMapException("그룹 목록에 가입되어있지 않는 그룹이 포함되어 있습니다.");
+            }
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/DeleteArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/DeleteArticleService.java
@@ -10,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeleteArticleService {
 
-  private final DeleteArticleRepository deleteArticleRepository;
+    private final DeleteArticleRepository deleteArticleRepository;
 
-  @Transactional
-  public void delete(Long articleId, Long memberId) {
-    int result = deleteArticleRepository.deleteById(articleId, memberId);
-    if (result == 0) {
-      throw new NotMatchMemberException("글을 삭제할 권한이 없습니다.");
+    @Transactional
+    public void delete(Long articleId, Long memberId) {
+        int result = deleteArticleRepository.deleteById(articleId, memberId);
+        if (result == 0) {
+            throw new NotMatchMemberException("글을 삭제할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/EditArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/EditArticleService.java
@@ -10,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EditArticleService {
 
-  private final EditArticleRepository editArticleRepository;
+    private final EditArticleRepository editArticleRepository;
 
-  @Transactional
-  public void edit(Long articleId, Long memberId, String newContent) {
-    int result = editArticleRepository.editArticle(articleId, memberId, newContent);
-    if (result == 0) {
-      throw new NotMatchMemberException("글을 수정할 권한이 없습니다.");
+    @Transactional
+    public void edit(Long articleId, Long memberId, String newContent) {
+        int result = editArticleRepository.editArticle(articleId, memberId, newContent);
+        if (result == 0) {
+            throw new NotMatchMemberException("글을 수정할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/FindArticleDetailsService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/FindArticleDetailsService.java
@@ -23,81 +23,81 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FindArticleDetailsService {
 
-  private final FindArticleRepository findArticleRepository;
+    private final FindArticleRepository findArticleRepository;
 
-  private final ArticleLikeRepository articleLikeRepository;
+    private final ArticleLikeRepository articleLikeRepository;
 
-  private final FindCommentRepository findCommentRepository;
+    private final FindCommentRepository findCommentRepository;
 
-  private final CommentLikeRepository commentLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
-  private final ArticleGroupRepository articleGroupRepository;
+    private final ArticleGroupRepository articleGroupRepository;
 
-  @Transactional(readOnly = true)
-  public ArticlePageResponse findDetails(Long articleId, CustomUserDetails userDetails) {
-    Article article = findArticleRepository.findById(articleId)
-        .orElseThrow(() -> new NotExistsException(" 댓글을 작성하려는 게시글이 존재하지 않습니다."));
-    ArticlePageResponse response = new ArticlePageResponse();
-    return findArticleResponse(article, userDetails, response);
-  }
-
-  private ArticlePageResponse findArticleResponse(Article article, CustomUserDetails userDetails,
-      ArticlePageResponse response) {
-    if (article.isPublic_map() == true) {
-      return findPublicArticle(article.getId(), userDetails, response);
+    @Transactional(readOnly = true)
+    public ArticlePageResponse findDetails(Long articleId, CustomUserDetails userDetails) {
+        Article article = findArticleRepository.findById(articleId)
+            .orElseThrow(() -> new NotExistsException(" 댓글을 작성하려는 게시글이 존재하지 않습니다."));
+        ArticlePageResponse response = new ArticlePageResponse();
+        return findArticleResponse(article, userDetails, response);
     }
-    if (article.isPrivate_map() == true) {
-      return findPrivateArticle(article, userDetails, response);
+
+    private ArticlePageResponse findArticleResponse(Article article, CustomUserDetails userDetails,
+        ArticlePageResponse response) {
+        if (article.isPublic_map() == true) {
+            return findPublicArticle(article.getId(), userDetails, response);
+        }
+        if (article.isPrivate_map() == true) {
+            return findPrivateArticle(article, userDetails, response);
+        }
+        return findGroupedArticle(article.getId(), userDetails, response);
     }
-    return findGroupedArticle(article.getId(), userDetails, response);
-  }
 
-  private ArticlePageResponse findPublicArticle(Long articleId, CustomUserDetails userDetails,
-      ArticlePageResponse response) {
-    addNonLoginInfo(articleId, response);
-    if (userDetails == null) {
-      response.addLoginInfo(false, null, null);
-      return response;
+    private ArticlePageResponse findPublicArticle(Long articleId, CustomUserDetails userDetails,
+        ArticlePageResponse response) {
+        addNonLoginInfo(articleId, response);
+        if (userDetails == null) {
+            response.addLoginInfo(false, null, null);
+            return response;
+        }
+        addLoginInfo(articleId, userDetails.getId(), response);
+        return response;
     }
-    addLoginInfo(articleId, userDetails.getId(), response);
-    return response;
-  }
 
-  private ArticlePageResponse findPrivateArticle(Article article, CustomUserDetails userDetails,
-      ArticlePageResponse response) {
-    if (userDetails == null) {
-      throw new NotAuthorizedOrExistException("해당 글에 접근할 권한이 없습니다.");
+    private ArticlePageResponse findPrivateArticle(Article article, CustomUserDetails userDetails,
+        ArticlePageResponse response) {
+        if (userDetails == null) {
+            throw new NotAuthorizedOrExistException("해당 글에 접근할 권한이 없습니다.");
+        }
+        ValidateIsMine.validateArticleIsMine(article.getMember_id(), userDetails.getId());
+        addNonLoginInfo(article.getId(), response);
+        addLoginInfo(article.getId(), userDetails.getId(), response);
+        return response;
     }
-    ValidateIsMine.validateArticleIsMine(article.getMember_id(), userDetails.getId());
-    addNonLoginInfo(article.getId(), response);
-    addLoginInfo(article.getId(), userDetails.getId(), response);
-    return response;
-  }
 
-  private ArticlePageResponse findGroupedArticle(Long articleId, CustomUserDetails userDetails,
-      ArticlePageResponse response) {
-    if (userDetails == null) {
-      throw new NotAuthorizedOrExistException("해당 글에 접근할 권한이 없습니다.");
+    private ArticlePageResponse findGroupedArticle(Long articleId, CustomUserDetails userDetails,
+        ArticlePageResponse response) {
+        if (userDetails == null) {
+            throw new NotAuthorizedOrExistException("해당 글에 접근할 권한이 없습니다.");
+        }
+        ValidateIsMine.validateInMyGroup(articleId, userDetails.getId(), articleGroupRepository);
+        addNonLoginInfo(articleId, response);
+        addLoginInfo(articleId, userDetails.getId(), response);
+        return response;
     }
-    ValidateIsMine.validateInMyGroup(articleId, userDetails.getId(), articleGroupRepository);
-    addNonLoginInfo(articleId, response);
-    addLoginInfo(articleId, userDetails.getId(), response);
-    return response;
-  }
 
-  private ArticlePageResponse addNonLoginInfo(Long articleId, ArticlePageResponse response) {
-    ArticleDetailsDto details = findArticleRepository.findArticleDetails(articleId);
-    List<CommentResponse> comments = findCommentRepository.findAllByArticleId(articleId);
-    response.addNonLoginInfo(details, comments);
-    return response;
-  }
+    private ArticlePageResponse addNonLoginInfo(Long articleId, ArticlePageResponse response) {
+        ArticleDetailsDto details = findArticleRepository.findArticleDetails(articleId);
+        List<CommentResponse> comments = findCommentRepository.findAllByArticleId(articleId);
+        response.addNonLoginInfo(details, comments);
+        return response;
+    }
 
-  private ArticlePageResponse addLoginInfo(Long articleId, Long memberId,
-      ArticlePageResponse response) {
-    Boolean myArticleLikeExists = articleLikeRepository.existsMyLike(
-        new ArticleLikeDto(articleId, memberId));
-    List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(articleId, memberId);
-    response.addLoginInfo(myArticleLikeExists, commentLikes, memberId);
-    return response;
-  }
+    private ArticlePageResponse addLoginInfo(Long articleId, Long memberId,
+        ArticlePageResponse response) {
+        Boolean myArticleLikeExists = articleLikeRepository.existsMyLike(
+            new ArticleLikeDto(articleId, memberId));
+        List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(articleId, memberId);
+        response.addLoginInfo(myArticleLikeExists, commentLikes, memberId);
+        return response;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/FindArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/FindArticleService.java
@@ -15,39 +15,39 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FindArticleService {
 
-  private final FindArticleRepository findArticleRepository;
+    private final FindArticleRepository findArticleRepository;
 
-  private final MemberGroupRepository memberGroupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  @Transactional(readOnly = true)
-  public List<ArticleMapResponse> findPublicMapArticles(
-      LocationRange locationRange) {
-    Long memberId = null;
-    return ArticleMapResponse.toResponses(findArticles(memberId, locationRange));
-  }
-
-  @Transactional(readOnly = true)
-  public List<ArticleMapResponse> findPrivateMapArticles(
-      Long memberId, LocationRange locationRange) {
-    return ArticleMapResponse.toResponses(findArticles(memberId, locationRange));
-  }
-
-  @Transactional(readOnly = true)
-  public List<ArticleMapResponse> findGroupedArticles(
-      Long memberId, Long groupId, LocationRange locationRange) {
-    validateHasJoined(groupId, memberId);
-    List<Article> articles = findArticleRepository.findArticlesByGroup(groupId, locationRange);
-    return ArticleMapResponse.toResponses(articles);
-  }
-
-  private List<Article> findArticles(Long memberId, LocationRange locationRange) {
-    return findArticleRepository.findArticles(memberId, locationRange);
-  }
-
-  private void validateHasJoined(Long groupId, Long memberId) {
-    boolean isPresent = memberGroupRepository.checkAlreadyJoined(groupId, memberId);
-    if (!isPresent) {
-      throw new NotExistsException("그룹에 속해있지 않습니다.");
+    @Transactional(readOnly = true)
+    public List<ArticleMapResponse> findPublicMapArticles(
+        LocationRange locationRange) {
+        Long memberId = null;
+        return ArticleMapResponse.toResponses(findArticles(memberId, locationRange));
     }
-  }
+
+    @Transactional(readOnly = true)
+    public List<ArticleMapResponse> findPrivateMapArticles(
+        Long memberId, LocationRange locationRange) {
+        return ArticleMapResponse.toResponses(findArticles(memberId, locationRange));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ArticleMapResponse> findGroupedArticles(
+        Long memberId, Long groupId, LocationRange locationRange) {
+        validateHasJoined(groupId, memberId);
+        List<Article> articles = findArticleRepository.findArticlesByGroup(groupId, locationRange);
+        return ArticleMapResponse.toResponses(articles);
+    }
+
+    private List<Article> findArticles(Long memberId, LocationRange locationRange) {
+        return findArticleRepository.findArticles(memberId, locationRange);
+    }
+
+    private void validateHasJoined(Long groupId, Long memberId) {
+        boolean isPresent = memberGroupRepository.checkAlreadyJoined(groupId, memberId);
+        if (!isPresent) {
+            throw new NotExistsException("그룹에 속해있지 않습니다.");
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/CreateArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/CreateArticleRepository.java
@@ -6,5 +6,5 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface CreateArticleRepository {
 
-  Long saveArticle(Article article);
+    Long saveArticle(Article article);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/DeleteArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/DeleteArticleRepository.java
@@ -6,6 +6,6 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface DeleteArticleRepository {
 
-  @Delete("DELETE FROM article WHERE id=#{articleId} and member_id=#{memberId}")
-  int deleteById(Long articleId, Long memberId);
+    @Delete("DELETE FROM article WHERE id=#{articleId} and member_id=#{memberId}")
+    int deleteById(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/EditArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/EditArticleRepository.java
@@ -6,6 +6,6 @@ import org.apache.ibatis.annotations.Update;
 @Mapper
 public interface EditArticleRepository {
 
-  @Update("UPDATE article SET content=#{content} WHERE id=#{articleId} and member_id=#{memberId}")
-  int editArticle(Long articleId, Long memberId, String content);
+    @Update("UPDATE article SET content=#{content} WHERE id=#{articleId} and member_id=#{memberId}")
+    int editArticle(Long articleId, Long memberId, String content);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -11,18 +11,18 @@ import java.util.List;
 @Mapper
 public interface FindArticleRepository {
 
-  List<Article> findArticles(
-      Long memberId,
-      LocationRange locationRange
-  );
+    List<Article> findArticles(
+        Long memberId,
+        LocationRange locationRange
+    );
 
-  List<Article> findArticlesByGroup(
-      Long groupId,
-      LocationRange locationRange
-  );
+    List<Article> findArticlesByGroup(
+        Long groupId,
+        LocationRange locationRange
+    );
 
-  @Select("Select * from article where id=#{articleId}")
-  Optional<Article> findById(Long articleId);
+    @Select("Select * from article where id=#{articleId}")
+    Optional<Article> findById(Long articleId);
 
-  ArticleDetailsDto findArticleDetails(Long articleId);
+    ArticleDetailsDto findArticleDetails(Long articleId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/domain/Article.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/domain/Article.java
@@ -13,38 +13,38 @@ import lombok.ToString;
 @NoArgsConstructor
 public class Article {
 
-  private Long id;
-  private String content;
-  private Date create_date;
-  private Double latitude;    // 위도
-  private Double longitude;   // 경도
-  private boolean private_map;
-  private boolean public_map;
-  private String title;
-  private Long member_id;
+    private Long id;
+    private String content;
+    private Date create_date;
+    private Double latitude;    // 위도
+    private Double longitude;   // 경도
+    private boolean private_map;
+    private boolean public_map;
+    private String title;
+    private Long member_id;
 
-  public Article(Long id, String content, Date create_date, Double latitude, Double longitude,
-      boolean private_map, boolean public_map, String title, Long member_id) {
-    this.id = id;
-    this.content = content;
-    this.create_date = create_date;
-    this.latitude = latitude;
-    this.longitude = longitude;
-    this.private_map = private_map;
-    this.public_map = public_map;
-    this.title = title;
-    this.member_id = member_id;
-  }
+    public Article(Long id, String content, Date create_date, Double latitude, Double longitude,
+        boolean private_map, boolean public_map, String title, Long member_id) {
+        this.id = id;
+        this.content = content;
+        this.create_date = create_date;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.private_map = private_map;
+        this.public_map = public_map;
+        this.title = title;
+        this.member_id = member_id;
+    }
 
-  public static Article createArticle(CreateArticleRequest request, Long userId) {
-    return Article.builder()
-        .content(request.getContent())
-        .latitude(request.getLatitude())
-        .longitude(request.getLongitude())
-        .public_map(request.isPublicMap())
-        .private_map(request.isPrivateMap())
-        .title(request.getTitle())
-        .create_date(new Date())
-        .member_id(userId).build();
-  }
+    public static Article createArticle(CreateArticleRequest request, Long userId) {
+        return Article.builder()
+            .content(request.getContent())
+            .latitude(request.getLatitude())
+            .longitude(request.getLongitude())
+            .public_map(request.isPublicMap())
+            .private_map(request.isPrivateMap())
+            .title(request.getTitle())
+            .create_date(new Date())
+            .member_id(userId).build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/domain/LocationRange.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/domain/LocationRange.java
@@ -6,15 +6,15 @@ import lombok.Getter;
 @Getter
 public class LocationRange {
 
-  private final double lowerLatitude;
-  private final double upperLatitude;
-  private final double lowerLongitude;
-  private final double upperLongitude;
+    private final double lowerLatitude;
+    private final double upperLatitude;
+    private final double lowerLongitude;
+    private final double upperLongitude;
 
-  public LocationRange(ArticleRangeRequest request) {
-    this.lowerLatitude = request.getLatitude() - request.getLatitudeRange();
-    this.upperLatitude = request.getLatitude() + request.getLatitudeRange();
-    this.lowerLongitude = request.getLongitude() - request.getLongitudeRange();
-    this.upperLongitude = request.getLongitude() + request.getLongitudeRange();
-  }
+    public LocationRange(ArticleRangeRequest request) {
+        this.lowerLatitude = request.getLatitude() - request.getLatitudeRange();
+        this.upperLatitude = request.getLatitude() + request.getLatitudeRange();
+        this.lowerLongitude = request.getLongitude() - request.getLongitudeRange();
+        this.upperLongitude = request.getLongitude() + request.getLongitudeRange();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetailsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetailsDto.java
@@ -7,24 +7,25 @@ import lombok.Getter;
 @Getter
 public class ArticleDetailsDto {
 
-  private Long id;
-  private String title;
-  private String content;
-  private Double latitude;
-  private Double longitude;
-  private AuthorDto author;
-  private Date createDate;
-  private Long totalLikes;
+    private Long id;
+    private String title;
+    private String content;
+    private Double latitude;
+    private Double longitude;
+    private AuthorDto author;
+    private Date createDate;
+    private Long totalLikes;
 
-  public ArticleDetailsDto(Long id, String title, String content, Double latitude, Double longitude,
-      Long userId, String nickName, String imageUrl, Date createDate, Long totalLikes) {
-    this.id = id;
-    this.title = title;
-    this.content = content;
-    this.latitude = latitude;
-    this.longitude = longitude;
-    this.author = new AuthorDto(userId, nickName, imageUrl);
-    this.createDate = createDate;
-    this.totalLikes = totalLikes;
-  }
+    public ArticleDetailsDto(Long id, String title, String content, Double latitude,
+        Double longitude,
+        Long userId, String nickName, String imageUrl, Date createDate, Long totalLikes) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.author = new AuthorDto(userId, nickName, imageUrl);
+        this.createDate = createDate;
+        this.totalLikes = totalLikes;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleMapResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleMapResponse.java
@@ -13,21 +13,21 @@ import java.util.stream.Collectors;
 @Getter
 public class ArticleMapResponse {
 
-  private Long id;
-  private Double latitude;
-  private Double longitude;
-  private String title;
+    private Long id;
+    private Double latitude;
+    private Double longitude;
+    private String title;
 
-  public static List<ArticleMapResponse> toResponses(List<Article> articles) {
-    if (Objects.isNull(articles)) {
-      return Collections.emptyList();
+    public static List<ArticleMapResponse> toResponses(List<Article> articles) {
+        if (Objects.isNull(articles)) {
+            return Collections.emptyList();
+        }
+        return articles.stream()
+            .map(article -> new ArticleMapResponse(
+                article.getId(),
+                article.getLatitude(),
+                article.getLongitude(),
+                article.getTitle()))
+            .collect(Collectors.toUnmodifiableList());
     }
-    return articles.stream()
-        .map(article -> new ArticleMapResponse(
-            article.getId(),
-            article.getLatitude(),
-            article.getLongitude(),
-            article.getTitle()))
-        .collect(Collectors.toUnmodifiableList());
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
@@ -7,32 +7,32 @@ import lombok.Getter;
 @Getter
 public class ArticlePageResponse {
 
-  private ArticleDetailsDto articleDetails;
-  private boolean articleLike;
-  private List<CommentResponse> comments;
-  private List<Long> commentLikes;
-  private Long myMemberId;
+    private ArticleDetailsDto articleDetails;
+    private boolean articleLike;
+    private List<CommentResponse> comments;
+    private List<Long> commentLikes;
+    private Long myMemberId;
 
-  public ArticlePageResponse(ArticleDetailsDto articleDetails, boolean articleLike,
-      List<CommentResponse> comments, List<Long> commentLikes, Long myMemberId) {
-    this.articleDetails = articleDetails;
-    this.articleLike = articleLike;
-    this.comments = comments;
-    this.commentLikes = commentLikes;
-    this.myMemberId = myMemberId;
-  }
+    public ArticlePageResponse(ArticleDetailsDto articleDetails, boolean articleLike,
+        List<CommentResponse> comments, List<Long> commentLikes, Long myMemberId) {
+        this.articleDetails = articleDetails;
+        this.articleLike = articleLike;
+        this.comments = comments;
+        this.commentLikes = commentLikes;
+        this.myMemberId = myMemberId;
+    }
 
-  public ArticlePageResponse() {
-  }
+    public ArticlePageResponse() {
+    }
 
-  public void addNonLoginInfo(ArticleDetailsDto articleDetails, List<CommentResponse> comments) {
-    this.articleDetails = articleDetails;
-    this.comments = comments;
-  }
+    public void addNonLoginInfo(ArticleDetailsDto articleDetails, List<CommentResponse> comments) {
+        this.articleDetails = articleDetails;
+        this.comments = comments;
+    }
 
-  public void addLoginInfo(boolean articleLike, List<Long> commentLikes, Long myMemberId) {
-    this.articleLike = articleLike;
-    this.commentLikes = commentLikes;
-    this.myMemberId = myMemberId;
-  }
+    public void addLoginInfo(boolean articleLike, List<Long> commentLikes, Long myMemberId) {
+        this.articleLike = articleLike;
+        this.commentLikes = commentLikes;
+        this.myMemberId = myMemberId;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleRangeRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleRangeRequest.java
@@ -5,16 +5,16 @@ import lombok.Getter;
 @Getter
 public class ArticleRangeRequest {
 
-  private final Double latitude;
-  private final Double latitudeRange;
-  private final Double longitude;
-  private final Double longitudeRange;
+    private final Double latitude;
+    private final Double latitudeRange;
+    private final Double longitude;
+    private final Double longitudeRange;
 
-  public ArticleRangeRequest(Double latitude, Double latitudeRange, Double longitude,
-      Double longitudeRange) {
-    this.latitude = latitude;
-    this.latitudeRange = latitudeRange;
-    this.longitude = longitude;
-    this.longitudeRange = longitudeRange;
-  }
+    public ArticleRangeRequest(Double latitude, Double latitudeRange, Double longitude,
+        Double longitudeRange) {
+        this.latitude = latitude;
+        this.latitudeRange = latitudeRange;
+        this.longitude = longitude;
+        this.longitudeRange = longitudeRange;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/CreateArticleRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/CreateArticleRequest.java
@@ -10,34 +10,34 @@ import java.util.List;
 @Getter
 public class CreateArticleRequest {
 
-  @NotEmpty(message = "제목을 입력해주세요.")
-  @NotBlank(message = "제목을 입력해주세요.")
-  @Size(max=50, message = "제목의 최대길이를 초과하였습니다.")
-  private String title;
+    @NotEmpty(message = "제목을 입력해주세요.")
+    @NotBlank(message = "제목을 입력해주세요.")
+    @Size(max = 50, message = "제목의 최대길이를 초과하였습니다.")
+    private String title;
 
-  @NotEmpty(message = "내용을 입력해주세요.")
-  @NotBlank(message = "내용을 입력해주세요.")
-  private String content;
+    @NotEmpty(message = "내용을 입력해주세요.")
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
 
-  private double latitude;    // 위도
+    private double latitude;    // 위도
 
-  private double longitude;   // 경도
-  private boolean publicMap;
-  private boolean privateMap;
-  private List<Long> groupIdsToBeIncluded;
+    private double longitude;   // 경도
+    private boolean publicMap;
+    private boolean privateMap;
+    private List<Long> groupIdsToBeIncluded;
 
-  public CreateArticleRequest(String title, String content, double latitude, double longitude,
-      boolean publicMap, boolean privateMap, List<Long> groupIdsToBeIncluded) {
-    this.title = title;
-    this.content = content;
-    this.latitude = latitude;
-    this.longitude = longitude;
-    this.publicMap = publicMap;
-    this.privateMap = privateMap;
-    this.groupIdsToBeIncluded = groupIdsToBeIncluded;
-  }
+    public CreateArticleRequest(String title, String content, double latitude, double longitude,
+        boolean publicMap, boolean privateMap, List<Long> groupIdsToBeIncluded) {
+        this.title = title;
+        this.content = content;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.publicMap = publicMap;
+        this.privateMap = privateMap;
+        this.groupIdsToBeIncluded = groupIdsToBeIncluded;
+    }
 
-  public void updateGroupIdList(List<Long> groupIdsToBeIncluded){
-    this.groupIdsToBeIncluded = groupIdsToBeIncluded;
-  }
+    public void updateGroupIdList(List<Long> groupIdsToBeIncluded) {
+        this.groupIdsToBeIncluded = groupIdsToBeIncluded;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/EditArticleContentRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/EditArticleContentRequest.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 @Getter
 public class EditArticleContentRequest {
 
-  private String newContent;
+    private String newContent;
 
-  public EditArticleContentRequest(String newContent) {
-    this.newContent = newContent;
-  }
+    public EditArticleContentRequest(String newContent) {
+        this.newContent = newContent;
+    }
 
-  public EditArticleContentRequest() {
-  }
+    public EditArticleContentRequest() {
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/exception/NotIncludedMapException.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/exception/NotIncludedMapException.java
@@ -2,7 +2,7 @@ package foot.footprint.domain.article.exception;
 
 public class NotIncludedMapException extends RuntimeException {
 
-  public NotIncludedMapException(String message) {
-    super(message);
-  }
+    public NotIncludedMapException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/exception/NotMatchMemberException.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/exception/NotMatchMemberException.java
@@ -2,7 +2,7 @@ package foot.footprint.domain.article.exception;
 
 public class NotMatchMemberException extends RuntimeException {
 
-  public NotMatchMemberException(String message) {
-    super(message);
-  }
+    public NotMatchMemberException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/api/ArticleLikeController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/api/ArticleLikeController.java
@@ -18,14 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/articles/{articleId}/like")
 public class ArticleLikeController {
 
-  private final ArticleLikeService articleLikeService;
+    private final ArticleLikeService articleLikeService;
 
-  @PostMapping
-  public ResponseEntity<Void> changeMyLike(@PathVariable("articleId") Long articleId,
-      @RequestParam(value = "hasiliked") Boolean hasILiked,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleId, userDetails.getId(), hasILiked);
-    articleLikeService.changeArticleLike(articleLikeDto);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
+    @PostMapping
+    public ResponseEntity<Void> changeMyLike(@PathVariable("articleId") Long articleId,
+        @RequestParam(value = "hasiliked") Boolean hasILiked,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleId, userDetails.getId(),
+            hasILiked);
+        articleLikeService.changeArticleLike(articleLikeDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/ArticleLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/ArticleLikeService.java
@@ -16,54 +16,55 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ArticleLikeService {
 
-  private final ArticleLikeRepository articleLikeRepository;
+    private final ArticleLikeRepository articleLikeRepository;
 
-  private final FindArticleRepository findArticleRepository;
+    private final FindArticleRepository findArticleRepository;
 
-  private final ArticleGroupRepository articleGroupRepository;
+    private final ArticleGroupRepository articleGroupRepository;
 
-  @Transactional
-  public void changeArticleLike(ArticleLikeDto articleLikeDto) {
-    Article article = findArticleRepository.findById(articleLikeDto.getArticleId())
-        .orElseThrow(() -> new NotExistsException(" 댓글을 작성하려는 게시글이 존재하지 않습니다."));
-    if (article.isPublic_map()) {
-      changePublicArticleLike(articleLikeDto);
-      return;
+    @Transactional
+    public void changeArticleLike(ArticleLikeDto articleLikeDto) {
+        Article article = findArticleRepository.findById(articleLikeDto.getArticleId())
+            .orElseThrow(() -> new NotExistsException(" 댓글을 작성하려는 게시글이 존재하지 않습니다."));
+        if (article.isPublic_map()) {
+            changePublicArticleLike(articleLikeDto);
+            return;
+        }
+        if (article.isPrivate_map()) {
+            changePrivateArticleLike(articleLikeDto, article.getMember_id());
+            return;
+        }
+        changeGroupedArticleLike(articleLikeDto);
     }
-    if (article.isPrivate_map()) {
-      changePrivateArticleLike(articleLikeDto, article.getMember_id());
-      return;
+
+    private void changePublicArticleLike(ArticleLikeDto articleLikeDto) {
+        changeLike(articleLikeDto);
     }
-    changeGroupedArticleLike(articleLikeDto);
-  }
 
-  private void changePublicArticleLike(ArticleLikeDto articleLikeDto) {
-    changeLike(articleLikeDto);
-  }
-
-  private void changePrivateArticleLike(ArticleLikeDto articleLikeDto, Long writerId) {
-    ValidateIsMine.validateArticleIsMine(writerId, articleLikeDto.getMemberId());
-    changeLike(articleLikeDto);
-  }
-
-  private void changeGroupedArticleLike(ArticleLikeDto articleLikeDto) {
-    ValidateIsMine.validateInMyGroup(articleLikeDto.getArticleId(), articleLikeDto.getMemberId(),
-        articleGroupRepository);
-    changeLike(articleLikeDto);
-  }
-
-  private void changeLike(ArticleLikeDto articleLikeDto) {
-    if (articleLikeDto.isHasILiked()) {
-      deleteLike(articleLikeDto);
-      return;
+    private void changePrivateArticleLike(ArticleLikeDto articleLikeDto, Long writerId) {
+        ValidateIsMine.validateArticleIsMine(writerId, articleLikeDto.getMemberId());
+        changeLike(articleLikeDto);
     }
-    articleLikeRepository.saveArticleLike(ArticleLike.createArticleLike(articleLikeDto));
-  }
 
-  private void deleteLike(ArticleLikeDto articleLikeDto) {
-    int deleted = articleLikeRepository.deleteArticleLike(articleLikeDto);
-    if (deleted == 0) {
-      throw new NotExistsException("이미 좋아요를 취소하였거나 누르지 않았습니다.");
+    private void changeGroupedArticleLike(ArticleLikeDto articleLikeDto) {
+        ValidateIsMine.validateInMyGroup(articleLikeDto.getArticleId(),
+            articleLikeDto.getMemberId(),
+            articleGroupRepository);
+        changeLike(articleLikeDto);
     }
-  }
+
+    private void changeLike(ArticleLikeDto articleLikeDto) {
+        if (articleLikeDto.isHasILiked()) {
+            deleteLike(articleLikeDto);
+            return;
+        }
+        articleLikeRepository.saveArticleLike(ArticleLike.createArticleLike(articleLikeDto));
+    }
+
+    private void deleteLike(ArticleLikeDto articleLikeDto) {
+        int deleted = articleLikeRepository.deleteArticleLike(articleLikeDto);
+        if (deleted == 0) {
+            throw new NotExistsException("이미 좋아요를 취소하였거나 누르지 않았습니다.");
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/dao/ArticleLikeRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/dao/ArticleLikeRepository.java
@@ -8,10 +8,10 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface ArticleLikeRepository {
 
-  boolean existsMyLike(ArticleLikeDto articleLikeDto);
+    boolean existsMyLike(ArticleLikeDto articleLikeDto);
 
-  @Delete("DELETE FROM article_like WHERE article_id=#{articleId} and member_id=#{memberId}")
-  int deleteArticleLike(ArticleLikeDto articleLikeDto);
+    @Delete("DELETE FROM article_like WHERE article_id=#{articleId} and member_id=#{memberId}")
+    int deleteArticleLike(ArticleLikeDto articleLikeDto);
 
-  int saveArticleLike(ArticleLike articleLike);
+    int saveArticleLike(ArticleLike articleLike);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/domain/ArticleLike.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/domain/ArticleLike.java
@@ -12,20 +12,20 @@ import lombok.ToString;
 @NoArgsConstructor
 public class ArticleLike {
 
-  private Long id;
-  private Long article_id;
-  private Long member_id;
+    private Long id;
+    private Long article_id;
+    private Long member_id;
 
-  public ArticleLike(Long id, Long article_id, Long member_id) {
-    this.id = id;
-    this.article_id = article_id;
-    this.member_id = member_id;
-  }
+    public ArticleLike(Long id, Long article_id, Long member_id) {
+        this.id = id;
+        this.article_id = article_id;
+        this.member_id = member_id;
+    }
 
-  public static ArticleLike createArticleLike(ArticleLikeDto articleLikeDto) {
-    return ArticleLike.builder()
-        .member_id(articleLikeDto.getMemberId())
-        .article_id(articleLikeDto.getArticleId())
-        .build();
-  }
+    public static ArticleLike createArticleLike(ArticleLikeDto articleLikeDto) {
+        return ArticleLike.builder()
+            .member_id(articleLikeDto.getMemberId())
+            .article_id(articleLikeDto.getArticleId())
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/dto/ArticleLikeDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/dto/ArticleLikeDto.java
@@ -4,18 +4,20 @@ import lombok.Getter;
 
 @Getter
 public class ArticleLikeDto {
-  private Long articleId;
-  private Long memberId;
-  private boolean hasILiked;
 
-  public ArticleLikeDto(Long articleId, Long memberId, boolean hasILiked) {
-    this.articleId = articleId;
-    this.memberId = memberId;
-    this.hasILiked = hasILiked;
-  }
-  public ArticleLikeDto(Long articleId, Long memberId) {
-    this.articleId = articleId;
-    this.memberId = memberId;
-    this.hasILiked = true;
-  }
+    private Long articleId;
+    private Long memberId;
+    private boolean hasILiked;
+
+    public ArticleLikeDto(Long articleId, Long memberId, boolean hasILiked) {
+        this.articleId = articleId;
+        this.memberId = memberId;
+        this.hasILiked = hasILiked;
+    }
+
+    public ArticleLikeDto(Long articleId, Long memberId) {
+        this.articleId = articleId;
+        this.memberId = memberId;
+        this.hasILiked = true;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/api/CreateCommentController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/api/CreateCommentController.java
@@ -20,16 +20,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CreateCommentController {
 
-  private final CreateCommentService createCommentService;
+    private final CreateCommentService createCommentService;
 
-  @PostMapping("/{articleId}/comments")
-  public ResponseEntity<CommentResponse> createOnPublicArticle(
-      @PathVariable("articleId") Long articleId,
-      @RequestBody @Valid CreateCommentRequest createCommentRequest,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    CommentResponse commentResponse = createCommentService.create(articleId,
-        createCommentRequest.getContent(), userDetails.getId());
+    @PostMapping("/{articleId}/comments")
+    public ResponseEntity<CommentResponse> createOnPublicArticle(
+        @PathVariable("articleId") Long articleId,
+        @RequestBody @Valid CreateCommentRequest createCommentRequest,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        CommentResponse commentResponse = createCommentService.create(articleId,
+            createCommentRequest.getContent(), userDetails.getId());
 
-    return ResponseEntity.status(HttpStatus.CREATED).body(commentResponse);
-  }
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentResponse);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/api/DeleteCommentController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/api/DeleteCommentController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DeleteCommentController {
 
-  private final DeleteCommentService deleteCommentService;
+    private final DeleteCommentService deleteCommentService;
 
-  @DeleteMapping("/{commentId}")
-  public ResponseEntity<Void> deleteComment(@PathVariable("commentId") Long commentId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    deleteCommentService.delete(commentId, userDetails.getId());
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable("commentId") Long commentId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        deleteCommentService.delete(commentId, userDetails.getId());
 
-    return ResponseEntity.noContent()
-        .build();
-  }
+        return ResponseEntity.noContent()
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/api/EditCommentController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/api/EditCommentController.java
@@ -20,14 +20,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/comments")
 public class EditCommentController {
 
-  private final EditCommentService editCommentService;
-  @PutMapping("/{commentId}")
-  public ResponseEntity<CommentResponse> editComment(
-      @PathVariable("commentId") Long commentId,
-      @RequestBody @Valid EditCommentRequest editCommentRequest,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    editCommentService.edit(commentId, userDetails.getId(), editCommentRequest.getContent());
-    return ResponseEntity.noContent()
-        .build();
-  }
+    private final EditCommentService editCommentService;
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> editComment(
+        @PathVariable("commentId") Long commentId,
+        @RequestBody @Valid EditCommentRequest editCommentRequest,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        editCommentService.edit(commentId, userDetails.getId(), editCommentRequest.getContent());
+        return ResponseEntity.noContent()
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/DeleteCommentService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/DeleteCommentService.java
@@ -10,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeleteCommentService {
 
-  private final DeleteCommentRepository deleteCommentRepository;
+    private final DeleteCommentRepository deleteCommentRepository;
 
-  @Transactional
-  public void delete(Long commentId, Long memberId) {
-    int result = deleteCommentRepository.deleteComment(commentId, memberId);
-    if (result == 0) {
-      throw new NotMatchMemberException("댓글을 삭제할 권한이 없습니다.");
+    @Transactional
+    public void delete(Long commentId, Long memberId) {
+        int result = deleteCommentRepository.deleteComment(commentId, memberId);
+        if (result == 0) {
+            throw new NotMatchMemberException("댓글을 삭제할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/EditCommentService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/EditCommentService.java
@@ -10,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EditCommentService {
 
-  private final EditCommentRepository editCommentRepository;
+    private final EditCommentRepository editCommentRepository;
 
-  @Transactional
-  public void edit(Long commentId, Long memberId, String newContent){
-    int result = editCommentRepository.editComment(commentId, memberId, newContent);
-    if(result == 0) {
-      throw new NotMatchMemberException("댓글을 수정할 권한이 없습니다.");
+    @Transactional
+    public void edit(Long commentId, Long memberId, String newContent) {
+        int result = editCommentRepository.editComment(commentId, memberId, newContent);
+        if (result == 0) {
+            throw new NotMatchMemberException("댓글을 수정할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/CreateCommentRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/CreateCommentRepository.java
@@ -6,5 +6,5 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface CreateCommentRepository {
 
-  Long saveComment(Comment comment);
+    Long saveComment(Comment comment);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/DeleteCommentRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/DeleteCommentRepository.java
@@ -6,6 +6,6 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface DeleteCommentRepository {
 
-  @Delete("DELETE FROM comment WHERE id=#{commentId} and member_id=#{memberId}")
-  int deleteComment(Long commentId, Long memberId);
+    @Delete("DELETE FROM comment WHERE id=#{commentId} and member_id=#{memberId}")
+    int deleteComment(Long commentId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/EditCommentRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/EditCommentRepository.java
@@ -6,6 +6,6 @@ import org.apache.ibatis.annotations.Update;
 @Mapper
 public interface EditCommentRepository {
 
-  @Update("UPDATE comment SET content=#{content} WHERE id=#{commentId} and member_id=#{memberId}")
-  int editComment(Long commentId, Long memberId, String content);
+    @Update("UPDATE comment SET content=#{content} WHERE id=#{commentId} and member_id=#{memberId}")
+    int editComment(Long commentId, Long memberId, String content);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/FindCommentRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dao/FindCommentRepository.java
@@ -9,8 +9,8 @@ import org.apache.ibatis.annotations.Select;
 @Mapper
 public interface FindCommentRepository {
 
-  @Select("select * from comment where id =#{commentId}")
-  Comment findById(Long commentId);
+    @Select("select * from comment where id =#{commentId}")
+    Comment findById(Long commentId);
 
-  List<CommentResponse> findAllByArticleId(Long articleId);
+    List<CommentResponse> findAllByArticleId(Long articleId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/domain/Comment.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/domain/Comment.java
@@ -15,35 +15,36 @@ import java.util.Objects;
 @NoArgsConstructor
 public class Comment {
 
-  private Long id;
+    private Long id;
 
-  private String content;
+    private String content;
 
-  private Date create_date;
+    private Date create_date;
 
-  private Long article_id;
+    private Long article_id;
 
-  private Long member_id;
+    private Long member_id;
 
-  public Comment(Long id, String content, Date create_date, Long article_id, Long member_id) {
-    this.id = id;
-    validate(content);
-    this.content = content;
-    this.create_date = create_date;
-    this.article_id = article_id;
-    this.member_id = member_id;
-  }
-  public Comment(String content, Date create_date, Long article_id, Long member_id) {
-    validate(content);
-    this.content = content;
-    this.create_date = create_date;
-    this.article_id = article_id;
-    this.member_id = member_id;
-  }
-
-  private void validate(String content) {
-    if (Objects.isNull(content) || content.trim().isEmpty()) {
-      throw new WrongInputException("내용이 비어있습니다.");
+    public Comment(Long id, String content, Date create_date, Long article_id, Long member_id) {
+        this.id = id;
+        validate(content);
+        this.content = content;
+        this.create_date = create_date;
+        this.article_id = article_id;
+        this.member_id = member_id;
     }
-  }
+
+    public Comment(String content, Date create_date, Long article_id, Long member_id) {
+        validate(content);
+        this.content = content;
+        this.create_date = create_date;
+        this.article_id = article_id;
+        this.member_id = member_id;
+    }
+
+    private void validate(String content) {
+        if (Objects.isNull(content) || content.trim().isEmpty()) {
+            throw new WrongInputException("내용이 비어있습니다.");
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
@@ -8,34 +8,34 @@ import lombok.Getter;
 @Getter
 public class CommentResponse {
 
-  private Long id;
-  private String content;
-  private AuthorDto author;
-  private Date createDate;
-  private Long totalLikes;
+    private Long id;
+    private String content;
+    private AuthorDto author;
+    private Date createDate;
+    private Long totalLikes;
 
-  public CommentResponse(Long id, String content, AuthorDto author, Date createDate) {
-    this.id = id;
-    this.content = content;
-    this.author = author;
-    this.createDate = createDate;
-  }
+    public CommentResponse(Long id, String content, AuthorDto author, Date createDate) {
+        this.id = id;
+        this.content = content;
+        this.author = author;
+        this.createDate = createDate;
+    }
 
-  public CommentResponse(Long id, String content, Long userId, String nickName, String imageUrl,
-      Date createDate, Long totalLikes) {
-    this.id = id;
-    this.content = content;
-    this.author = new AuthorDto(userId, nickName, imageUrl);
-    this.createDate = createDate;
-    this.totalLikes = totalLikes;
-  }
+    public CommentResponse(Long id, String content, Long userId, String nickName, String imageUrl,
+        Date createDate, Long totalLikes) {
+        this.id = id;
+        this.content = content;
+        this.author = new AuthorDto(userId, nickName, imageUrl);
+        this.createDate = createDate;
+        this.totalLikes = totalLikes;
+    }
 
-  public static CommentResponse toCommentResponse(Comment comment, AuthorDto authorDto) {
-    return new CommentResponse(
-        comment.getId(),
-        comment.getContent(),
-        authorDto,
-        comment.getCreate_date()
-    );
-  }
+    public static CommentResponse toCommentResponse(Comment comment, AuthorDto authorDto) {
+        return new CommentResponse(
+            comment.getId(),
+            comment.getContent(),
+            authorDto,
+            comment.getCreate_date()
+        );
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CreateCommentRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CreateCommentRequest.java
@@ -7,14 +7,14 @@ import lombok.Getter;
 @Getter
 public class CreateCommentRequest {
 
-  @NotEmpty(message = "빈 댓글은 작성할 수 없습니다.")
-  @NotBlank(message = "빈 댓글은 작성할 수 없습니다.")
-  private String content;
+    @NotEmpty(message = "빈 댓글은 작성할 수 없습니다.")
+    @NotBlank(message = "빈 댓글은 작성할 수 없습니다.")
+    private String content;
 
-  public CreateCommentRequest(String content) {
-    this.content = content;
-  }
+    public CreateCommentRequest(String content) {
+        this.content = content;
+    }
 
-  public CreateCommentRequest() {
-  }
+    public CreateCommentRequest() {
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/EditCommentRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/EditCommentRequest.java
@@ -7,14 +7,14 @@ import lombok.Getter;
 @Getter
 public class EditCommentRequest {
 
-  @NotEmpty(message = "빈 댓글로 수정할 수 없습니다.")
-  @NotBlank(message = "빈 댓글로 수정할 수 없습니다.")
-  private String content;
+    @NotEmpty(message = "빈 댓글로 수정할 수 없습니다.")
+    @NotBlank(message = "빈 댓글로 수정할 수 없습니다.")
+    private String content;
 
-  public EditCommentRequest(String content) {
-    this.content = content;
-  }
+    public EditCommentRequest(String content) {
+        this.content = content;
+    }
 
-  public EditCommentRequest() {
-  }
+    public EditCommentRequest() {
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/api/CommentLikeController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/api/CommentLikeController.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CommentLikeController {
 
-  private final CommentLikeService commentLikeService;
+    private final CommentLikeService commentLikeService;
 
-  @PostMapping("/{commentId}/like")
-  public ResponseEntity<Void> changeMyLike(@PathVariable("commentId") Long commentId,
-      @PathVariable("articleId") Long articleId,
-      @RequestParam(value = "hasiliked") Boolean hasILiked,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    commentLikeService.changeMyLike(commentId, articleId, hasILiked, userDetails.getId());
-    return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
+    @PostMapping("/{commentId}/like")
+    public ResponseEntity<Void> changeMyLike(@PathVariable("commentId") Long commentId,
+        @PathVariable("articleId") Long articleId,
+        @RequestParam(value = "hasiliked") Boolean hasILiked,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        commentLikeService.changeMyLike(commentId, articleId, hasILiked, userDetails.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/CommentLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/CommentLikeService.java
@@ -15,55 +15,55 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentLikeService {
 
-  private final FindArticleRepository findArticleRepository;
+    private final FindArticleRepository findArticleRepository;
 
-  private final CommentLikeRepository commentLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
-  private final ArticleGroupRepository articleGroupRepository;
+    private final ArticleGroupRepository articleGroupRepository;
 
-  @Transactional
-  public void changeMyLike(Long commentId, Long articleId, Boolean hasILiked, Long memberId) {
-    Article article = findArticleRepository.findById(articleId)
-        .orElseThrow(() -> new NotExistsException("해당하는 게시글이 존재하지 않습니다."));
-    if (article.isPublic_map()) {
-      changeLikeByPublic(commentId, memberId, hasILiked);
-      return;
+    @Transactional
+    public void changeMyLike(Long commentId, Long articleId, Boolean hasILiked, Long memberId) {
+        Article article = findArticleRepository.findById(articleId)
+            .orElseThrow(() -> new NotExistsException("해당하는 게시글이 존재하지 않습니다."));
+        if (article.isPublic_map()) {
+            changeLikeByPublic(commentId, memberId, hasILiked);
+            return;
+        }
+        if (article.isPrivate_map()) {
+            changeLikeByPrivate(article, commentId, memberId, hasILiked);
+            return;
+        }
+        changeLikeByGrouped(articleId, commentId, memberId, hasILiked);
     }
-    if (article.isPrivate_map()) {
-      changeLikeByPrivate(article, commentId, memberId, hasILiked);
-      return;
+
+    private void changeLikeByPublic(Long commentId, Long memberId, boolean hasILiked) {
+        changeLike(commentId, memberId, hasILiked);
     }
-    changeLikeByGrouped(articleId, commentId, memberId, hasILiked);
-  }
 
-  private void changeLikeByPublic(Long commentId, Long memberId, boolean hasILiked) {
-    changeLike(commentId, memberId, hasILiked);
-  }
-
-  private void changeLikeByPrivate(Article article, Long commentId, Long memberId,
-      boolean hasILiked) {
-    ValidateIsMine.validateArticleIsMine(article.getMember_id(), memberId);
-    changeLike(commentId, memberId, hasILiked);
-  }
-
-  private void changeLikeByGrouped(Long articleId, Long commentId, Long memberId,
-      boolean hasILiked) {
-    ValidateIsMine.validateInMyGroup(articleId, memberId, articleGroupRepository);
-    changeLike(commentId, memberId, hasILiked);
-  }
-
-  private void changeLike(Long commentId, Long memberId, boolean hasILiked) {
-    if (hasILiked) {
-      deleteLike(commentId, memberId);
-      return;
+    private void changeLikeByPrivate(Article article, Long commentId, Long memberId,
+        boolean hasILiked) {
+        ValidateIsMine.validateArticleIsMine(article.getMember_id(), memberId);
+        changeLike(commentId, memberId, hasILiked);
     }
-    commentLikeRepository.saveCommentLike(new CommentLike(commentId, memberId));
-  }
 
-  private void deleteLike(Long commentId, Long memberId) {
-    int deleted = commentLikeRepository.deleteCommentLike(commentId, memberId);
-    if (deleted == 0) {
-      throw new NotExistsException("이미 좋아요를 취소하였거나 누르지 않았습니다.");
+    private void changeLikeByGrouped(Long articleId, Long commentId, Long memberId,
+        boolean hasILiked) {
+        ValidateIsMine.validateInMyGroup(articleId, memberId, articleGroupRepository);
+        changeLike(commentId, memberId, hasILiked);
     }
-  }
+
+    private void changeLike(Long commentId, Long memberId, boolean hasILiked) {
+        if (hasILiked) {
+            deleteLike(commentId, memberId);
+            return;
+        }
+        commentLikeRepository.saveCommentLike(new CommentLike(commentId, memberId));
+    }
+
+    private void deleteLike(Long commentId, Long memberId) {
+        int deleted = commentLikeRepository.deleteCommentLike(commentId, memberId);
+        if (deleted == 0) {
+            throw new NotExistsException("이미 좋아요를 취소하였거나 누르지 않았습니다.");
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/dao/CommentLikeRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/dao/CommentLikeRepository.java
@@ -8,10 +8,10 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface CommentLikeRepository {
 
-  int saveCommentLike(CommentLike commentLike);
+    int saveCommentLike(CommentLike commentLike);
 
-  @Delete("DELETE FROM comment_like WHERE comment_id=#{commentId} and member_id=#{memberId}")
-  int deleteCommentLike(Long commentId, Long memberId);
+    @Delete("DELETE FROM comment_like WHERE comment_id=#{commentId} and member_id=#{memberId}")
+    int deleteCommentLike(Long commentId, Long memberId);
 
-  List<Long> findCommentIdsILiked(Long articleId, Long memberId);
+    List<Long> findCommentIdsILiked(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/domain/CommentLike.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/domain/CommentLike.java
@@ -11,18 +11,18 @@ import lombok.ToString;
 @NoArgsConstructor
 public class CommentLike {
 
-  private Long id;
-  private Long comment_id;
-  private Long member_id;
+    private Long id;
+    private Long comment_id;
+    private Long member_id;
 
-  public CommentLike(Long id, Long comment_id, Long member_id) {
-    this.id = id;
-    this.comment_id = comment_id;
-    this.member_id = member_id;
-  }
+    public CommentLike(Long id, Long comment_id, Long member_id) {
+        this.id = id;
+        this.comment_id = comment_id;
+        this.member_id = member_id;
+    }
 
-  public CommentLike(Long comment_id, Long member_id) {
-    this.comment_id = comment_id;
-    this.member_id = member_id;
-  }
+    public CommentLike(Long comment_id, Long member_id) {
+        this.comment_id = comment_id;
+        this.member_id = member_id;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/ChangeImportantController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/ChangeImportantController.java
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/groups")
 public class ChangeImportantController {
 
-  private final ChangeImportantService changeImportantService;
+    private final ChangeImportantService changeImportantService;
 
-  @PutMapping("/{groupId}/important")
-  public ResponseEntity<Void> changeImportant(@PathVariable("groupId") Long groupId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    changeImportantService.changeImportant(groupId, userDetails.getId());
+    @PutMapping("/{groupId}/important")
+    public ResponseEntity<Void> changeImportant(@PathVariable("groupId") Long groupId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        changeImportantService.changeImportant(groupId, userDetails.getId());
 
-    return ResponseEntity.noContent().build();
-  }
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/CreateGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/CreateGroupController.java
@@ -18,15 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/groups")
 public class CreateGroupController {
 
-  private final CreateGroupService createGroupService;
+    private final CreateGroupService createGroupService;
 
-  @PostMapping
-  public ResponseEntity<Void> create(@RequestBody @Valid CreateGroupRequest createGroupRequest,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    String groupName = createGroupRequest.getGroupName();
-    Long groupId = createGroupService.createGroup(groupName, userDetails.getId());
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody @Valid CreateGroupRequest createGroupRequest,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        String groupName = createGroupRequest.getGroupName();
+        Long groupId = createGroupService.createGroup(groupName, userDetails.getId());
 
-    return ResponseEntity.created(URI.create("/groups/" + groupId))
-        .build();
-  }
+        return ResponseEntity.created(URI.create("/groups/" + groupId))
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/DeportMemberController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/DeportMemberController.java
@@ -15,15 +15,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DeportMemberController {
 
-  private final DeportMemberService deportMemberService;
+    private final DeportMemberService deportMemberService;
 
-  @DeleteMapping("/{groupId}/{memberId}")
+    @DeleteMapping("/{groupId}/{memberId}")
 
-  public ResponseEntity<Void> deportMember(@PathVariable("groupId") Long groupId,
-      @PathVariable("memberId") Long memberId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    deportMemberService.deport(groupId, memberId, userDetails.getId());
+    public ResponseEntity<Void> deportMember(@PathVariable("groupId") Long groupId,
+        @PathVariable("memberId") Long memberId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        deportMemberService.deport(groupId, memberId, userDetails.getId());
 
-    return ResponseEntity.noContent().build();
-  }
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/EditGroupNameController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/EditGroupNameController.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class EditGroupNameController {
 
-  private final EditGroupNameService editGroupNameService;
+    private final EditGroupNameService editGroupNameService;
 
-  @PutMapping("/{groupId}")
-  public ResponseEntity<Void> editGroupName(@PathVariable("groupId") Long groupId,
-      @RequestBody EditGroupNameRequest request,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    editGroupNameService.change(groupId, userDetails.getId(), request.getNewName());
+    @PutMapping("/{groupId}")
+    public ResponseEntity<Void> editGroupName(@PathVariable("groupId") Long groupId,
+        @RequestBody EditGroupNameRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        editGroupNameService.change(groupId, userDetails.getId(), request.getNewName());
 
-    return ResponseEntity.noContent().build();
-  }
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/FindGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/FindGroupController.java
@@ -18,30 +18,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FindGroupController {
 
-  private final FindGroupService findGroupService;
+    private final FindGroupService findGroupService;
 
-  @GetMapping("/mine/important")
-  public ResponseEntity<List<GroupSummaryResponse>> findMyImportantGroups(
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    List<GroupSummaryResponse> responses = findGroupService.findMyImportantGroups(
-        userDetails.getId());
+    @GetMapping("/mine/important")
+    public ResponseEntity<List<GroupSummaryResponse>> findMyImportantGroups(
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<GroupSummaryResponse> responses = findGroupService.findMyImportantGroups(
+            userDetails.getId());
 
-    return ResponseEntity.ok().body(responses);
-  }
+        return ResponseEntity.ok().body(responses);
+    }
 
-  @GetMapping("/mine")
-  public ResponseEntity<List<GroupSummaryResponse>> findMyGroups(
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    List<GroupSummaryResponse> responses = findGroupService.findMyGroups(userDetails.getId());
+    @GetMapping("/mine")
+    public ResponseEntity<List<GroupSummaryResponse>> findMyGroups(
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<GroupSummaryResponse> responses = findGroupService.findMyGroups(userDetails.getId());
 
-    return ResponseEntity.ok().body(responses);
-  }
+        return ResponseEntity.ok().body(responses);
+    }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<GroupDetailsResponse> findOne(@PathVariable("id") Long groupId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    GroupDetailsResponse response = findGroupService.findOne(groupId, userDetails.getId());
+    @GetMapping("/{id}")
+    public ResponseEntity<GroupDetailsResponse> findOne(@PathVariable("id") Long groupId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        GroupDetailsResponse response = findGroupService.findOne(groupId, userDetails.getId());
 
-    return ResponseEntity.ok().body(response);
-  }
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/JoinGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/JoinGroupController.java
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class JoinGroupController {
 
-  private final JoinGroupService joinGroupService;
+    private final JoinGroupService joinGroupService;
 
-  @PostMapping("/admission")
-  public ResponseEntity<Void> join(@RequestParam(value = "invitation_code") String invitationCode,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    Long groupId = joinGroupService.join(invitationCode, userDetails.getId());
+    @PostMapping("/admission")
+    public ResponseEntity<Void> join(@RequestParam(value = "invitation_code") String invitationCode,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long groupId = joinGroupService.join(invitationCode, userDetails.getId());
 
-    return ResponseEntity.created(URI.create("/groups/" + groupId))
-        .build();
-  }
+        return ResponseEntity.created(URI.create("/groups/" + groupId))
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/SecessionGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/SecessionGroupController.java
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SecessionGroupController {
 
-  private final SecessionGroupService secessionGroupService;
+    private final SecessionGroupService secessionGroupService;
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> sessionGroup(@PathVariable("id") Long groupId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    secessionGroupService.secessionGroup(groupId, userDetails.getId());
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> sessionGroup(@PathVariable("id") Long groupId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        secessionGroupService.secessionGroup(groupId, userDetails.getId());
 
-    return ResponseEntity.noContent().build();
-  }
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/ChangeImportantService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/ChangeImportantService.java
@@ -10,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChangeImportantService {
 
-  private final MemberGroupRepository memberGroupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  @Transactional
-  public void changeImportant(Long groupId, Long memberId) {
-    int result = memberGroupRepository.changeImportant(groupId, memberId);
-    if (result == 0) {
-      throw new NotAuthorizedOrExistException("해당 그룹이 존재하지 않거나 즐겨찾기를 변경할 권한이 없습니다.");
+    @Transactional
+    public void changeImportant(Long groupId, Long memberId) {
+        int result = memberGroupRepository.changeImportant(groupId, memberId);
+        if (result == 0) {
+            throw new NotAuthorizedOrExistException("해당 그룹이 존재하지 않거나 즐겨찾기를 변경할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/CreateGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/CreateGroupService.java
@@ -13,26 +13,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CreateGroupService {
 
-  private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository;
 
-  private final MemberGroupRepository memberGroupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  @Transactional
-  public Long createGroup(String groupName, Long creatorId) {
-    Group newGroup = saveGroup(groupName, creatorId);
-    memberGroupRepository.saveMemberGroup(MemberGroup.createMemberGroup(newGroup));
-    return newGroup.getId();
-  }
+    @Transactional
+    public Long createGroup(String groupName, Long creatorId) {
+        Group newGroup = saveGroup(groupName, creatorId);
+        memberGroupRepository.saveMemberGroup(MemberGroup.createMemberGroup(newGroup));
+        return newGroup.getId();
+    }
 
-  private Group saveGroup(String groupName, Long creatorId) {
-    Group newGroup = new Group(groupName, creatorId);
-    groupRepository.saveGroup(newGroup);
-    newGroup.addInvitationCode(generateInvitationCode(newGroup.getId()));
-    groupRepository.updateInvitationCode(newGroup);
-    return newGroup;
-  }
+    private Group saveGroup(String groupName, Long creatorId) {
+        Group newGroup = new Group(groupName, creatorId);
+        groupRepository.saveGroup(newGroup);
+        newGroup.addInvitationCode(generateInvitationCode(newGroup.getId()));
+        groupRepository.updateInvitationCode(newGroup);
+        return newGroup;
+    }
 
-  private String generateInvitationCode(Long groupId) {
-    return RandomStringGenerator.generate(5) + groupId;
-  }
+    private String generateInvitationCode(Long groupId) {
+        return RandomStringGenerator.generate(5) + groupId;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/DeportMemberService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/DeportMemberService.java
@@ -14,27 +14,27 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeportMemberService {
 
-  private final MemberGroupRepository memberGroupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository;
 
-  @Transactional
-  public void deport(Long groupId, Long memberId, Long myId) {
-    validateGroupIsMine(groupId, myId, memberId);
-    int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
-    if (deleted == 0) {
-      throw new NotExistsException("해당인원이 그룹에 이미 존재하지 않습니다.");
+    @Transactional
+    public void deport(Long groupId, Long memberId, Long myId) {
+        validateGroupIsMine(groupId, myId, memberId);
+        int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
+        if (deleted == 0) {
+            throw new NotExistsException("해당인원이 그룹에 이미 존재하지 않습니다.");
+        }
     }
-  }
 
-  private void validateGroupIsMine(Long groupId, Long myId, Long memberId) {
-    if (memberId == myId) {
-      throw new NotMatchMemberException("자기 자신을 탈퇴할 수 없습니다.");
+    private void validateGroupIsMine(Long groupId, Long myId, Long memberId) {
+        if (memberId == myId) {
+            throw new NotMatchMemberException("자기 자신을 탈퇴할 수 없습니다.");
+        }
+        Group group = groupRepository.findById(groupId)
+            .orElseThrow(() -> new NotExistsException("해당하는 그룹이 존재하지 않습니다."));
+        if (!Objects.equals(group.getOwner_id(), myId)) {
+            throw new NotMatchMemberException("그룹원을 추방시킬 권한이 없습니다.");
+        }
     }
-    Group group = groupRepository.findById(groupId)
-        .orElseThrow(() -> new NotExistsException("해당하는 그룹이 존재하지 않습니다."));
-    if (!Objects.equals(group.getOwner_id(), myId)) {
-      throw new NotMatchMemberException("그룹원을 추방시킬 권한이 없습니다.");
-    }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/EditGroupNameService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/EditGroupNameService.java
@@ -10,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EditGroupNameService {
 
-  private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository;
 
-  @Transactional
-  public void change(Long groupId, Long ownerId, String newName) {
-    int edited = groupRepository.changeGroupName(groupId, ownerId, newName);
-    if (edited == 0) {
-      throw new NotAuthorizedOrExistException("그룹 이름 변경할 권한이 없습니다.");
+    @Transactional
+    public void change(Long groupId, Long ownerId, String newName) {
+        int edited = groupRepository.changeGroupName(groupId, ownerId, newName);
+        if (edited == 0) {
+            throw new NotAuthorizedOrExistException("그룹 이름 변경할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/FindGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/FindGroupService.java
@@ -14,22 +14,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FindGroupService {
 
-  private final MemberGroupRepository memberGroupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository;
 
-  @Transactional(readOnly = true)
-  public List<GroupSummaryResponse> findMyImportantGroups(Long memberId) {
-    return memberGroupRepository.findMyImportantGroups(memberId);
-  }
+    @Transactional(readOnly = true)
+    public List<GroupSummaryResponse> findMyImportantGroups(Long memberId) {
+        return memberGroupRepository.findMyImportantGroups(memberId);
+    }
 
-  public List<GroupSummaryResponse> findMyGroups(Long memberId) {
-    return memberGroupRepository.findMyGroups(memberId);
-  }
+    public List<GroupSummaryResponse> findMyGroups(Long memberId) {
+        return memberGroupRepository.findMyGroups(memberId);
+    }
 
-  public GroupDetailsResponse findOne(Long groupId, Long memberId) {
-    GroupDetailsResponse response = groupRepository.findGroupDetails(groupId, memberId)
-        .orElseThrow(() -> new NotAuthorizedOrExistException("그룹을 조회할 권한이 없습니다."));
-    return response;
-  }
+    public GroupDetailsResponse findOne(Long groupId, Long memberId) {
+        GroupDetailsResponse response = groupRepository.findGroupDetails(groupId, memberId)
+            .orElseThrow(() -> new NotAuthorizedOrExistException("그룹을 조회할 권한이 없습니다."));
+        return response;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/JoinGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/JoinGroupService.java
@@ -14,30 +14,31 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class JoinGroupService {
 
-  private final GroupRepository groupRepository;
-  private final MemberGroupRepository memberGroupRepository;
+    private final GroupRepository groupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  @Transactional
-  public Long join(String invitationCode, Long memberId) {
-    Group group = findGroup(invitationCode);
-    validateHasJoined(group, memberId);
-    saveMemberGroup(group, memberId);
-    return group.getId();
-  }
-
-  private Group findGroup(String invitationCode) {
-    return groupRepository.findByInvitationCode(invitationCode)
-        .orElseThrow(() -> new NotExistsException("존재하지 않는 초대코드입니다."));
-  }
-
-  private void validateHasJoined(Group group, Long memberId) {
-    boolean isPresent = memberGroupRepository.checkAlreadyJoined(group.getId(), memberId);
-    if (isPresent) {
-      throw new AlreadyJoinedException("이미 가입된 그룹입니다.");
+    @Transactional
+    public Long join(String invitationCode, Long memberId) {
+        Group group = findGroup(invitationCode);
+        validateHasJoined(group, memberId);
+        saveMemberGroup(group, memberId);
+        return group.getId();
     }
-  }
 
-  private void saveMemberGroup(Group group, Long memberId) {
-    memberGroupRepository.saveMemberGroup(MemberGroup.createMemberGroup(group.getId(), memberId));
-  }
+    private Group findGroup(String invitationCode) {
+        return groupRepository.findByInvitationCode(invitationCode)
+            .orElseThrow(() -> new NotExistsException("존재하지 않는 초대코드입니다."));
+    }
+
+    private void validateHasJoined(Group group, Long memberId) {
+        boolean isPresent = memberGroupRepository.checkAlreadyJoined(group.getId(), memberId);
+        if (isPresent) {
+            throw new AlreadyJoinedException("이미 가입된 그룹입니다.");
+        }
+    }
+
+    private void saveMemberGroup(Group group, Long memberId) {
+        memberGroupRepository.saveMemberGroup(
+            MemberGroup.createMemberGroup(group.getId(), memberId));
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/SecessionGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/SecessionGroupService.java
@@ -11,27 +11,27 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SecessionGroupService {
 
-  private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository;
 
-  private final MemberGroupRepository memberGroupRepository;
+    private final MemberGroupRepository memberGroupRepository;
 
-  @Transactional
-  public void secessionGroup(Long groupId, Long memberId) {
-    deleteMemberGroup(groupId, memberId);
-    deleteGroupIfMemberIsNotExist(groupId);
-  }
-
-  private void deleteMemberGroup(Long groupId, Long memberId) {
-    int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
-    if (deleted == 0) {
-      throw new NotExistsException("이미 탈퇴한 그룹이거나 존재하지 않는 그룹입니다.");
+    @Transactional
+    public void secessionGroup(Long groupId, Long memberId) {
+        deleteMemberGroup(groupId, memberId);
+        deleteGroupIfMemberIsNotExist(groupId);
     }
-  }
 
-  private void deleteGroupIfMemberIsNotExist(Long groupId) {
-    Long memberCount = memberGroupRepository.countMemberGroup(groupId);
-    if (memberCount <= 0) {
-      groupRepository.deleteById(groupId);
+    private void deleteMemberGroup(Long groupId, Long memberId) {
+        int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
+        if (deleted == 0) {
+            throw new NotExistsException("이미 탈퇴한 그룹이거나 존재하지 않는 그룹입니다.");
+        }
     }
-  }
+
+    private void deleteGroupIfMemberIsNotExist(Long groupId) {
+        Long memberCount = memberGroupRepository.countMemberGroup(groupId);
+        if (memberCount <= 0) {
+            groupRepository.deleteById(groupId);
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/ArticleGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/ArticleGroupRepository.java
@@ -7,7 +7,7 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface ArticleGroupRepository {
 
-  int saveArticleGroupList(List<ArticleGroup> articleGroups);
+    int saveArticleGroupList(List<ArticleGroup> articleGroups);
 
-  boolean existsArticleInMyGroup(Long articleId, Long memberId);
+    boolean existsArticleInMyGroup(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
@@ -12,23 +12,23 @@ import org.apache.ibatis.annotations.Update;
 @Mapper
 public interface GroupRepository {
 
-  Long saveGroup(Group group);
+    Long saveGroup(Group group);
 
-  @Select("Select * from group_table where id=#{groupId}")
-  Optional<Group> findById(Long groupId);
+    @Select("Select * from group_table where id=#{groupId}")
+    Optional<Group> findById(Long groupId);
 
-  @Select("Select * from group_table where invitation_code=#{invitationCode}")
-  Optional<Group> findByInvitationCode(String invitationCode);
+    @Select("Select * from group_table where invitation_code=#{invitationCode}")
+    Optional<Group> findByInvitationCode(String invitationCode);
 
-  @Update("UPDATE group_table SET invitation_code=#{invitation_code} WHERE id=#{id}")
-  int updateInvitationCode(Group group);
+    @Update("UPDATE group_table SET invitation_code=#{invitation_code} WHERE id=#{id}")
+    int updateInvitationCode(Group group);
 
-  int changeGroupName(Long groupId, Long ownerId, String newName);
+    int changeGroupName(Long groupId, Long ownerId, String newName);
 
-  @Delete("DELETE FROM group_table WHERE id=#{groupId}")
-  int deleteById(Long groupId);
+    @Delete("DELETE FROM group_table WHERE id=#{groupId}")
+    int deleteById(Long groupId);
 
-  List<Long> findAllByMemberId(Long memberId);
+    List<Long> findAllByMemberId(Long memberId);
 
-  Optional<GroupDetailsResponse> findGroupDetails(Long groupId, Long memberId);
+    Optional<GroupDetailsResponse> findGroupDetails(Long groupId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
@@ -10,22 +10,22 @@ import org.apache.ibatis.annotations.Select;
 @Mapper
 public interface MemberGroupRepository {
 
-  Long saveMemberGroup(MemberGroup memberGroup);
+    Long saveMemberGroup(MemberGroup memberGroup);
 
-  boolean checkAlreadyJoined(Long groupId, Long memberId);
+    boolean checkAlreadyJoined(Long groupId, Long memberId);
 
-  @Delete("DELETE FROM member_group WHERE group_id=#{groupId} and member_id=#{memberId}")
-  int deleteMemberGroup(Long groupId, Long memberId);
+    @Delete("DELETE FROM member_group WHERE group_id=#{groupId} and member_id=#{memberId}")
+    int deleteMemberGroup(Long groupId, Long memberId);
 
-  @Select("SELECT COUNT(*) FROM member_group WHERE group_id=#{groupId}")
-  Long countMemberGroup(Long groupId);
+    @Select("SELECT COUNT(*) FROM member_group WHERE group_id=#{groupId}")
+    Long countMemberGroup(Long groupId);
 
-  int changeImportant(Long groupId, Long memberId);
+    int changeImportant(Long groupId, Long memberId);
 
-  @Select("SELECT * FROM member_group WHERE id=#{id}")
-  MemberGroup findById(Long id);
+    @Select("SELECT * FROM member_group WHERE id=#{id}")
+    MemberGroup findById(Long id);
 
-  List<GroupSummaryResponse> findMyImportantGroups(Long memberId);
+    List<GroupSummaryResponse> findMyImportantGroups(Long memberId);
 
-  List<GroupSummaryResponse> findMyGroups(Long memberId);
+    List<GroupSummaryResponse> findMyGroups(Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/domain/ArticleGroup.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/domain/ArticleGroup.java
@@ -12,22 +12,22 @@ import lombok.ToString;
 @NoArgsConstructor
 public class ArticleGroup {
 
-  private Long id;
-  private Date create_date;
-  private Long article_id;
-  private Long group_id;
+    private Long id;
+    private Date create_date;
+    private Long article_id;
+    private Long group_id;
 
-  public ArticleGroup(Long id, Date create_date, Long article_id, Long group_id) {
-    this.id = id;
-    this.create_date = create_date;
-    this.article_id = article_id;
-    this.group_id = group_id;
-  }
+    public ArticleGroup(Long id, Date create_date, Long article_id, Long group_id) {
+        this.id = id;
+        this.create_date = create_date;
+        this.article_id = article_id;
+        this.group_id = group_id;
+    }
 
-  public static ArticleGroup createArticleGroup(Long groupId, Long articleId) {
-    return ArticleGroup.builder()
-        .create_date(new Date())
-        .group_id(groupId)
-        .article_id(articleId).build();
-  }
+    public static ArticleGroup createArticleGroup(Long groupId, Long articleId) {
+        return ArticleGroup.builder()
+            .create_date(new Date())
+            .group_id(groupId)
+            .article_id(articleId).build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/domain/Group.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/domain/Group.java
@@ -14,38 +14,38 @@ import lombok.ToString;
 @NoArgsConstructor
 public class Group {
 
-  private Long id;
-  private Date create_date;
-  private String invitation_code;
-  private String name;
-  private Long owner_id;
+    private Long id;
+    private Date create_date;
+    private String invitation_code;
+    private String name;
+    private Long owner_id;
 
-  public Group(Long id, Date create_date, String invitation_code, String name, Long owner_id) {
-    this.id = id;
-    this.create_date = create_date;
-    addInvitationCode(invitation_code);
-    validate(name);
-    this.name = name;
-    this.owner_id = owner_id;
-  }
-
-  public Group(String name, Long owner_id) {
-    this.create_date = new Date();
-    validate(name);
-    this.name = name;
-    this.owner_id = owner_id;
-  }
-
-  private void validate(String name) {
-    if (Objects.isNull(name)) {
-      throw new WrongInputException("그룹이름이 null 일 수 없습니다.");
+    public Group(Long id, Date create_date, String invitation_code, String name, Long owner_id) {
+        this.id = id;
+        this.create_date = create_date;
+        addInvitationCode(invitation_code);
+        validate(name);
+        this.name = name;
+        this.owner_id = owner_id;
     }
-  }
 
-  public void addInvitationCode(String invitation_code) {
-    if (Objects.nonNull(this.invitation_code) && !this.invitation_code.isEmpty()) {
-      throw new WrongInputException("초대코드는 처음 한번만 정할 수 있습니다. 이미 부여된 초대코드가 존재합니다.");
+    public Group(String name, Long owner_id) {
+        this.create_date = new Date();
+        validate(name);
+        this.name = name;
+        this.owner_id = owner_id;
     }
-    this.invitation_code = invitation_code;
-  }
+
+    private void validate(String name) {
+        if (Objects.isNull(name)) {
+            throw new WrongInputException("그룹이름이 null 일 수 없습니다.");
+        }
+    }
+
+    public void addInvitationCode(String invitation_code) {
+        if (Objects.nonNull(this.invitation_code) && !this.invitation_code.isEmpty()) {
+            throw new WrongInputException("초대코드는 처음 한번만 정할 수 있습니다. 이미 부여된 초대코드가 존재합니다.");
+        }
+        this.invitation_code = invitation_code;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/domain/MemberGroup.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/domain/MemberGroup.java
@@ -13,41 +13,42 @@ import lombok.ToString;
 @NoArgsConstructor
 public class MemberGroup {
 
-  private Long id;
-  private Date create_date;
-  private Long group_id;
-  private Long member_id;
-  private boolean important;
+    private Long id;
+    private Date create_date;
+    private Long group_id;
+    private Long member_id;
+    private boolean important;
 
-  public MemberGroup(Long id, Date create_date, Long group_id, Long member_id, boolean important) {
-    this.id = id;
-    this.create_date = create_date;
-    this.group_id = group_id;
-    this.member_id = member_id;
-    this.important = important;
-  }
-
-  public static MemberGroup createMemberGroup(Group group){
-    return MemberGroup.builder()
-        .create_date(new Date())
-        .group_id(group.getId())
-        .member_id(group.getOwner_id())
-        .important(false).build();
-  }
-
-  public static MemberGroup createMemberGroup(Long groupId, Long memberId){
-    return MemberGroup.builder()
-        .create_date(new Date())
-        .group_id(groupId)
-        .member_id(memberId)
-        .important(false).build();
-  }
-
-  public void changeImportant() {
-    if (Objects.isNull(important)) {
-      important = true;
-    } else {
-      important = !important;
+    public MemberGroup(Long id, Date create_date, Long group_id, Long member_id,
+        boolean important) {
+        this.id = id;
+        this.create_date = create_date;
+        this.group_id = group_id;
+        this.member_id = member_id;
+        this.important = important;
     }
-  }
+
+    public static MemberGroup createMemberGroup(Group group) {
+        return MemberGroup.builder()
+            .create_date(new Date())
+            .group_id(group.getId())
+            .member_id(group.getOwner_id())
+            .important(false).build();
+    }
+
+    public static MemberGroup createMemberGroup(Long groupId, Long memberId) {
+        return MemberGroup.builder()
+            .create_date(new Date())
+            .group_id(groupId)
+            .member_id(memberId)
+            .important(false).build();
+    }
+
+    public void changeImportant() {
+        if (Objects.isNull(important)) {
+            important = true;
+        } else {
+            important = !important;
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/CreateGroupRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/CreateGroupRequest.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 @Getter
 public class CreateGroupRequest {
 
-  @NotEmpty(message = "빈 그룹이름을 생성할 수 없습니다.")
-  @NotBlank(message = "빈 그룹이름을 생성할 수 없습니다.")
-  @Size(max = 20, message = "그룹이름은 20자 내로만 생성할 수 있습니다.")
-  private String groupName;
+    @NotEmpty(message = "빈 그룹이름을 생성할 수 없습니다.")
+    @NotBlank(message = "빈 그룹이름을 생성할 수 없습니다.")
+    @Size(max = 20, message = "그룹이름은 20자 내로만 생성할 수 있습니다.")
+    private String groupName;
 
-  public CreateGroupRequest(String groupName) {
-    this.groupName = groupName;
-  }
+    public CreateGroupRequest(String groupName) {
+        this.groupName = groupName;
+    }
 
-  public CreateGroupRequest() {
-  }
+    public CreateGroupRequest() {
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/EditGroupNameRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/EditGroupNameRequest.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 @Getter
 public class EditGroupNameRequest {
 
-  @NotEmpty(message = "빈 그룹이름을 생성할 수 없습니다.")
-  @NotBlank(message = "빈 그룹이름을 생성할 수 없습니다.")
-  @Size(max = 20, message = "그룹이름은 20자 내로만 생성할 수 있습니다.")
-  private String newName;
+    @NotEmpty(message = "빈 그룹이름을 생성할 수 없습니다.")
+    @NotBlank(message = "빈 그룹이름을 생성할 수 없습니다.")
+    @Size(max = 20, message = "그룹이름은 20자 내로만 생성할 수 있습니다.")
+    private String newName;
 
-  public EditGroupNameRequest(String newName) {
-    this.newName = newName;
-  }
+    public EditGroupNameRequest(String newName) {
+        this.newName = newName;
+    }
 
-  public EditGroupNameRequest() {
-  }
+    public EditGroupNameRequest() {
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupDetailsResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupDetailsResponse.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GroupDetailsResponse {
 
-  private Long id;
-  private String name;
-  private String invitationCode;
-  private Boolean important;
-  private Date createDate;
-  private List<MemberDto> memberDetails;
+    private Long id;
+    private String name;
+    private String invitationCode;
+    private Boolean important;
+    private Date createDate;
+    private List<MemberDto> memberDetails;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupSummaryResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupSummaryResponse.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GroupSummaryResponse {
 
-  private Long id;
-  private String name;
+    private Long id;
+    private String name;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupSummaryResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/GroupSummaryResponse.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GroupSummaryResponse {
 
-    private Long id;
+    private Long groupId;
     private String name;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/MemberDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/MemberDto.java
@@ -8,7 +8,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberDto {
-  private Long id;
-  private String nickName;
-  private String imageUrl;
+
+    private Long id;
+    private String nickName;
+    private String imageUrl;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/exception/AlreadyJoinedException.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/exception/AlreadyJoinedException.java
@@ -2,7 +2,7 @@ package foot.footprint.domain.group.exception;
 
 public class AlreadyJoinedException extends RuntimeException {
 
-  public AlreadyJoinedException(String message) {
-    super(message);
-  }
+    public AlreadyJoinedException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/util/RandomStringGenerator.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/util/RandomStringGenerator.java
@@ -4,17 +4,17 @@ import java.util.Random;
 
 public class RandomStringGenerator {
 
-  public static String generate(int length) {
-    StringBuilder stringBuilder = new StringBuilder();
+    public static String generate(int length) {
+        StringBuilder stringBuilder = new StringBuilder();
 
-    for (int i = 0; i < length; i++) {
-      stringBuilder.append(generateUpperCase());
+        for (int i = 0; i < length; i++) {
+            stringBuilder.append(generateUpperCase());
+        }
+        return stringBuilder.toString();
     }
-    return stringBuilder.toString();
-  }
 
-  private static char generateUpperCase() {
-    Random r = new Random();
-    return (char) (r.nextInt(26) + 'a');
-  }
+    private static char generateUpperCase() {
+        Random r = new Random();
+        return (char) (r.nextInt(26) + 'a');
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/api/AuthController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/api/AuthController.java
@@ -18,21 +18,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
-  private final AuthService authService;
+    private final AuthService authService;
 
-  @PostMapping("/login")
-  public ResponseEntity<AuthResponse> login(
-      @RequestBody @Valid LoginRequest loginRequest) {
-    String token = authService.login(loginRequest);
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(
+        @RequestBody @Valid LoginRequest loginRequest) {
+        String token = authService.login(loginRequest);
 
-    return ResponseEntity.ok(new AuthResponse(token));
-  }
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
 
-  @PostMapping("/signup")
-  public ResponseEntity<Void> registerMember(@RequestBody @Valid SignUpRequest signUpRequest) {
-    authService.signUp(signUpRequest);
+    @PostMapping("/signup")
+    public ResponseEntity<Void> registerMember(@RequestBody @Valid SignUpRequest signUpRequest) {
+        authService.signUp(signUpRequest);
 
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .build();
-  }
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/api/MemberController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/api/MemberController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/member/me")
 public class MemberController {
 
-  private final MemberService memberService;
+    private final MemberService memberService;
 
-  @GetMapping("/image")
-  public ResponseEntity<MemberImageResponse> findMemberImageUrl(
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    MemberImageResponse response = memberService.findImageUrl(userDetails.getId());
+    @GetMapping("/image")
+    public ResponseEntity<MemberImageResponse> findMemberImageUrl(
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MemberImageResponse response = memberService.findImageUrl(userDetails.getId());
 
-    return ResponseEntity.ok()
-        .body(response);
-  }
+        return ResponseEntity.ok()
+            .body(response);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/api/MemberController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package foot.footprint.domain.member.api;
 
 import foot.footprint.domain.member.application.MemberService;
 import foot.footprint.domain.member.dto.MemberImageResponse;
+import foot.footprint.domain.member.dto.MyPageResponse;
 import foot.footprint.global.security.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,14 @@ public class MemberController {
         @AuthenticationPrincipal CustomUserDetails userDetails) {
         MemberImageResponse response = memberService.findImageUrl(userDetails.getId());
 
-        return ResponseEntity.ok()
-            .body(response);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<MyPageResponse> findMine(
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MyPageResponse response = memberService.findMyPageInfo(userDetails.getId());
+
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/application/AuthService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/application/AuthService.java
@@ -18,38 +18,38 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-  private final MemberRepository memberRepository;
-  private final PasswordEncoder passwordEncoder;
-  private final JwtTokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider tokenProvider;
 
-  @Transactional(readOnly = true)
-  public String login(LoginRequest loginRequest) {
-    Member member = findMember(loginRequest);
-    verifyPassword(loginRequest, member);
-    return tokenProvider.createAccessToken(String.valueOf(member.getId()), Role.USER);
-  }
-
-  @Transactional
-  public void signUp(SignUpRequest signUpRequest) {
-    verifyEmail(signUpRequest);
-    Member member = Member.createMember(signUpRequest, passwordEncoder);
-    memberRepository.saveMember(member);
-  }
-
-  private Member findMember(LoginRequest loginRequest) {
-    return memberRepository.findByEmail(loginRequest.getEmail())
-        .orElseThrow(() -> new NotExistsException("존재하지 않는 이메일입니다."));
-  }
-
-  private void verifyPassword(LoginRequest loginRequest, Member member) {
-    if (!passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
-      throw new NotMatchPasswordException("비밀번호가 틀렸습니다.");
+    @Transactional(readOnly = true)
+    public String login(LoginRequest loginRequest) {
+        Member member = findMember(loginRequest);
+        verifyPassword(loginRequest, member);
+        return tokenProvider.createAccessToken(String.valueOf(member.getId()), Role.USER);
     }
-  }
 
-  private void verifyEmail(SignUpRequest signUpRequest) {
-    if (memberRepository.existsByEmail(signUpRequest.getEmail())) {
-      throw new AlreadyExistedEmailException("이미 사용중인 이메일입니다.");
+    @Transactional
+    public void signUp(SignUpRequest signUpRequest) {
+        verifyEmail(signUpRequest);
+        Member member = Member.createMember(signUpRequest, passwordEncoder);
+        memberRepository.saveMember(member);
     }
-  }
+
+    private Member findMember(LoginRequest loginRequest) {
+        return memberRepository.findByEmail(loginRequest.getEmail())
+            .orElseThrow(() -> new NotExistsException("존재하지 않는 이메일입니다."));
+    }
+
+    private void verifyPassword(LoginRequest loginRequest, Member member) {
+        if (!passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
+            throw new NotMatchPasswordException("비밀번호가 틀렸습니다.");
+        }
+    }
+
+    private void verifyEmail(SignUpRequest signUpRequest) {
+        if (memberRepository.existsByEmail(signUpRequest.getEmail())) {
+            throw new AlreadyExistedEmailException("이미 사용중인 이메일입니다.");
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/application/MemberService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/application/MemberService.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.member.application;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.domain.member.dto.MemberImageResponse;
+import foot.footprint.domain.member.dto.MyPageResponse;
 import foot.footprint.global.error.exception.NotExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,8 +18,12 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberImageResponse findImageUrl(Long memberId) {
         Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotExistsException(
-                "존재하지 않는 회원입니다."));
+            .orElseThrow(() -> new NotExistsException("존재하지 않는 회원입니다."));
         return new MemberImageResponse(member.getId(), member.getImage_url());
+    }
+
+    @Transactional(readOnly = true)
+    public MyPageResponse findMyPageInfo(Long id) {
+        return memberRepository.findMyPageDetails(id);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/application/MemberService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/application/MemberService.java
@@ -12,13 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-  private final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-  @Transactional(readOnly = true)
-  public MemberImageResponse findImageUrl(Long memberId) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new NotExistsException(
-            "존재하지 않는 회원입니다."));
-    return new MemberImageResponse(member.getId(), member.getImage_url());
-  }
+    @Transactional(readOnly = true)
+    public MemberImageResponse findImageUrl(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NotExistsException(
+                "존재하지 않는 회원입니다."));
+        return new MemberImageResponse(member.getId(), member.getImage_url());
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dao/MemberRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dao/MemberRepository.java
@@ -9,17 +9,17 @@ import java.util.Optional;
 @Mapper
 public interface MemberRepository {
 
-  Long saveMember(Member member);
+    Long saveMember(Member member);
 
-  @Select("SELECT * FROM member WHERE id=#{id}")
-  Optional<Member> findById(Long id);
+    @Select("SELECT * FROM member WHERE id=#{id}")
+    Optional<Member> findById(Long id);
 
-  @Select("SELECT * FROM member WHERE email=#{email}")
-  Optional<Member> findByEmail(String email);
+    @Select("SELECT * FROM member WHERE email=#{email}")
+    Optional<Member> findByEmail(String email);
 
-  @Update("UPDATE member SET refresh_token=#{token} WHERE id=#{id}")
-  void updateRefreshToken(Long id, String token);
+    @Update("UPDATE member SET refresh_token=#{token} WHERE id=#{id}")
+    void updateRefreshToken(Long id, String token);
 
-  @Select("SELECT EXISTS (SELECT 1 FROM member WHERE email = #{email})")
-  boolean existsByEmail(String email);
+    @Select("SELECT EXISTS (SELECT 1 FROM member WHERE email = #{email})")
+    boolean existsByEmail(String email);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dao/MemberRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dao/MemberRepository.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.member.dao;
 
 import foot.footprint.domain.member.domain.Member;
+import foot.footprint.domain.member.dto.MyPageResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
@@ -22,4 +23,6 @@ public interface MemberRepository {
 
     @Select("SELECT EXISTS (SELECT 1 FROM member WHERE email = #{email})")
     boolean existsByEmail(String email);
+
+    MyPageResponse findMyPageDetails(Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/domain/AuthProvider.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/domain/AuthProvider.java
@@ -5,27 +5,27 @@ import foot.footprint.global.typeHandler.CodeEnumTypeHandler;
 import org.apache.ibatis.type.MappedTypes;
 
 public enum AuthProvider implements CodeEnum {
-  local("LOCAL"),
-  google("GOOGLE"),
-  naver("NAVER"),
-  kakao("KAKAO");
+    local("LOCAL"),
+    google("GOOGLE"),
+    naver("NAVER"),
+    kakao("KAKAO");
 
-  private String code;
+    private String code;
 
-  AuthProvider(String code) {
-    this.code = code;
-  }
-
-  @MappedTypes(AuthProvider.class)
-  public static class TypeHandler extends CodeEnumTypeHandler<AuthProvider> {
-
-    public TypeHandler() {
-      super(AuthProvider.class);
+    AuthProvider(String code) {
+        this.code = code;
     }
-  }
 
-  @Override
-  public String getCode() {
-    return code;
-  }
+    @MappedTypes(AuthProvider.class)
+    public static class TypeHandler extends CodeEnumTypeHandler<AuthProvider> {
+
+        public TypeHandler() {
+            super(AuthProvider.class);
+        }
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/domain/Member.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/domain/Member.java
@@ -14,39 +14,40 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @NoArgsConstructor
 public class Member {
 
-  private Long id;
-  private String email;
-  private String image_url;
-  private Date join_date;
-  private String nick_name;
-  private String password;
-  private AuthProvider provider;
-  private String provider_id;
-  private Role role;
-  private String refresh_token;
+    private Long id;
+    private String email;
+    private String image_url;
+    private Date join_date;
+    private String nick_name;
+    private String password;
+    private AuthProvider provider;
+    private String provider_id;
+    private Role role;
+    private String refresh_token;
 
-  public Member(Long id, String email, String image_url, Date join_date, String nick_name,
-      String password, AuthProvider provider, String provider_id, Role role, String refresh_token) {
-    this.id = id;
-    this.email = email;
-    this.image_url = image_url;
-    this.join_date = join_date;
-    this.nick_name = nick_name;
-    this.password = password;
-    this.provider = provider;
-    this.provider_id = provider_id;
-    this.role = role;
-    this.refresh_token = refresh_token;
-  }
+    public Member(Long id, String email, String image_url, Date join_date, String nick_name,
+        String password, AuthProvider provider, String provider_id, Role role,
+        String refresh_token) {
+        this.id = id;
+        this.email = email;
+        this.image_url = image_url;
+        this.join_date = join_date;
+        this.nick_name = nick_name;
+        this.password = password;
+        this.provider = provider;
+        this.provider_id = provider_id;
+        this.role = role;
+        this.refresh_token = refresh_token;
+    }
 
-  public static Member createMember(SignUpRequest request, PasswordEncoder passwordEncoder){
-    return Member.builder()
-        .email(request.getEmail())
-        .image_url("https://ifh.cc/g/2tAMnG.png")
-        .provider(AuthProvider.local)
-        .nick_name(request.getNickName())
-        .role(Role.USER)
-        .join_date(new Date())
-        .password(passwordEncoder.encode(request.getPassword())).build();
-  }
+    public static Member createMember(SignUpRequest request, PasswordEncoder passwordEncoder) {
+        return Member.builder()
+            .email(request.getEmail())
+            .image_url("https://ifh.cc/g/2tAMnG.png")
+            .provider(AuthProvider.local)
+            .nick_name(request.getNickName())
+            .role(Role.USER)
+            .join_date(new Date())
+            .password(passwordEncoder.encode(request.getPassword())).build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/domain/Role.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/domain/Role.java
@@ -5,24 +5,24 @@ import foot.footprint.global.typeHandler.CodeEnumTypeHandler;
 import org.apache.ibatis.type.MappedTypes;
 
 public enum Role implements CodeEnum {
-  USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+    USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
 
-  private String code;
+    private String code;
 
-  Role(String code) {
-    this.code = code;
-  }
-
-  @MappedTypes(Role.class)
-  public static class TypeHandler extends CodeEnumTypeHandler<Role> {
-
-    public TypeHandler() {
-      super(Role.class);
+    Role(String code) {
+        this.code = code;
     }
-  }
 
-  @Override
-  public String getCode() {
-    return code;
-  }
+    @MappedTypes(Role.class)
+    public static class TypeHandler extends CodeEnumTypeHandler<Role> {
+
+        public TypeHandler() {
+            super(Role.class);
+        }
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dto/AuthResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dto/AuthResponse.java
@@ -10,10 +10,10 @@ import lombok.NoArgsConstructor;
 @Getter
 public class AuthResponse {
 
-  private String accessToken;
-  private String tokenType = "Bearer";
+    private String accessToken;
+    private String tokenType = "Bearer";
 
-  public AuthResponse(String accessToken) {
-    this.accessToken = accessToken;
-  }
+    public AuthResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dto/LoginRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dto/LoginRequest.java
@@ -12,14 +12,14 @@ import lombok.Getter;
 @Getter
 public class LoginRequest {
 
-  @Email
-  @NotBlank
-  @NotEmpty
-  @Size(min = 4, max = 30)
-  private String email;
+    @Email
+    @NotBlank
+    @NotEmpty
+    @Size(min = 4, max = 30)
+    private String email;
 
-  @NotBlank
-  @NotEmpty
-  @Size(min = 4, max = 30)
-  private String password;
+    @NotBlank
+    @NotEmpty
+    @Size(min = 4, max = 30)
+    private String password;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dto/MemberImageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dto/MemberImageResponse.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MemberImageResponse {
 
-  private Long memberId;
-  private String imageUrl;
+    private Long memberId;
+    private String imageUrl;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dto/MyArticleResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dto/MyArticleResponse.java
@@ -1,0 +1,18 @@
+package foot.footprint.domain.member.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyArticleResponse {
+
+    private Long articleId;
+    private String title;
+    private Date createDate;
+    private Long totalLikes;
+    private Long totalComments;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dto/MyPageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dto/MyPageResponse.java
@@ -1,0 +1,22 @@
+package foot.footprint.domain.member.dto;
+
+import foot.footprint.domain.group.dto.GroupSummaryResponse;
+import java.sql.Timestamp;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyPageResponse {
+
+    private Long memberId;
+    private String imageUrl;
+    private String nickName;
+    private String email;
+    private Timestamp visitDate;
+    List<MyArticleResponse> myArticles;
+    List<GroupSummaryResponse> myGroups;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/dto/SignUpRequest.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/dto/SignUpRequest.java
@@ -11,19 +11,19 @@ import lombok.Getter;
 @Getter
 public class SignUpRequest {
 
-  @NotBlank
-  @NotEmpty
-  @Size(min = 4, max = 15)
-  private String nickName;
+    @NotBlank
+    @NotEmpty
+    @Size(min = 4, max = 15)
+    private String nickName;
 
-  @Email
-  @NotBlank
-  @NotEmpty
-  @Size(min = 4, max = 30)
-  private String email;
+    @Email
+    @NotBlank
+    @NotEmpty
+    @Size(min = 4, max = 30)
+    private String email;
 
-  @NotBlank
-  @NotEmpty
-  @Size(min = 4, max = 30)
-  private String password;
+    @NotBlank
+    @NotEmpty
+    @Size(min = 4, max = 30)
+    private String password;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/exception/AlreadyExistedEmailException.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/exception/AlreadyExistedEmailException.java
@@ -2,7 +2,7 @@ package foot.footprint.domain.member.exception;
 
 public class AlreadyExistedEmailException extends RuntimeException {
 
-  public AlreadyExistedEmailException(String message) {
-    super(message);
-  }
+    public AlreadyExistedEmailException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/exception/NotMatchPasswordException.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/exception/NotMatchPasswordException.java
@@ -2,7 +2,7 @@ package foot.footprint.domain.member.exception;
 
 public class NotMatchPasswordException extends RuntimeException {
 
-  public NotMatchPasswordException(String message) {
-    super(message);
-  }
+    public NotMatchPasswordException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/config/PasswordConfig.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/config/PasswordConfig.java
@@ -8,8 +8,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 public class PasswordConfig {
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/config/SecurityConfig.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/config/SecurityConfig.java
@@ -17,50 +17,50 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final CustomOAuth2UserService customOAuth2UserService;
-  private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
-  private final OAuth2AuthenticationSuccessHandler authenticationSuccessHandler;
-  private final OAuth2AuthenticationFailureHandler authenticationFailureHandler;
-  private final JwtAuthenticationFilter jwtAuthenticationFilter;
-  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+    private final OAuth2AuthenticationSuccessHandler authenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler authenticationFailureHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
-  @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.httpBasic().disable()
-        .cors()
-        .and()
-        .csrf().disable()
-        .formLogin().disable()
-        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        .and()
-        .authorizeRequests()
-        .antMatchers("/token/**").permitAll()
-        .antMatchers(HttpMethod.GET, "/articles/public/**").permitAll()
-        .antMatchers(HttpMethod.GET, "/articles/details/**").permitAll()
-        .antMatchers(HttpMethod.POST, "/auth/**").permitAll()
-        .anyRequest().authenticated()
-        .and()
-        .oauth2Login()
-        .authorizationEndpoint()
-        .baseUri("/oauth2/authorize")
-        .authorizationRequestRepository(cookieAuthorizationRequestRepository)
-        .and()
-        .redirectionEndpoint()
-        .baseUri("/oauth2/callback/*")
-        .and()
-        .userInfoEndpoint()
-        .userService(customOAuth2UserService)
-        .and()
-        .successHandler(authenticationSuccessHandler)
-        .failureHandler(authenticationFailureHandler);
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.httpBasic().disable()
+            .cors()
+            .and()
+            .csrf().disable()
+            .formLogin().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .authorizeRequests()
+            .antMatchers("/token/**").permitAll()
+            .antMatchers(HttpMethod.GET, "/articles/public/**").permitAll()
+            .antMatchers(HttpMethod.GET, "/articles/details/**").permitAll()
+            .antMatchers(HttpMethod.POST, "/auth/**").permitAll()
+            .anyRequest().authenticated()
+            .and()
+            .oauth2Login()
+            .authorizationEndpoint()
+            .baseUri("/oauth2/authorize")
+            .authorizationRequestRepository(cookieAuthorizationRequestRepository)
+            .and()
+            .redirectionEndpoint()
+            .baseUri("/oauth2/callback/*")
+            .and()
+            .userInfoEndpoint()
+            .userService(customOAuth2UserService)
+            .and()
+            .successHandler(authenticationSuccessHandler)
+            .failureHandler(authenticationFailureHandler);
 
-    http.exceptionHandling()
-        .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 401
-        .accessDeniedHandler(jwtAccessDeniedHandler);    // 403
+        http.exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 401
+            .accessDeniedHandler(jwtAccessDeniedHandler);    // 403
 
-    http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-    return http.build();
-  }
+        return http.build();
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/config/WebConfig.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/config/WebConfig.java
@@ -7,15 +7,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-  private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:3000";
+    private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:3000";
 
-  @Override
-  public void addCorsMappings(CorsRegistry registry) {
-    registry.addMapping("/**")
-        .allowedOrigins(DEVELOP_FRONT_ADDRESS)
-        .allowedMethods("GET", "POST", "PUT", "DELETE")
-        .exposedHeaders("location")
-        .allowedHeaders("*")
-        .allowCredentials(true);
-  }
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(DEVELOP_FRONT_ADDRESS)
+            .allowedMethods("GET", "POST", "PUT", "DELETE")
+            .exposedHeaders("location")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/domain/AuthorDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/domain/AuthorDto.java
@@ -6,17 +6,17 @@ import lombok.Getter;
 @Getter
 public class AuthorDto {
 
-  private Long id;
-  private String nickName;
-  private String imageUrl;
+    private Long id;
+    private String nickName;
+    private String imageUrl;
 
-  public AuthorDto(Long id, String nickName, String imageUrl) {
-    this.id = id;
-    this.nickName = nickName;
-    this.imageUrl = imageUrl;
-  }
+    public AuthorDto(Long id, String nickName, String imageUrl) {
+        this.id = id;
+        this.nickName = nickName;
+        this.imageUrl = imageUrl;
+    }
 
-  public static AuthorDto buildAuthorDto(Member member) {
-    return new AuthorDto(member.getId(), member.getNick_name(), member.getImage_url());
-  }
+    public static AuthorDto buildAuthorDto(Member member) {
+        return new AuthorDto(member.getId(), member.getNick_name(), member.getImage_url());
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/error/ErrorResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/error/ErrorResponse.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 @Getter
 public class ErrorResponse {
 
-  private String errorMessage;
+    private String errorMessage;
 
-  public ErrorResponse(String errorMessage){
-    this.errorMessage = errorMessage;
-  }
+    public ErrorResponse(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/error/ExceptionAdvice.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/error/ExceptionAdvice.java
@@ -21,98 +21,105 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class ExceptionAdvice {
 
-  @ExceptionHandler(NotIncludedMapException.class)
-  public ResponseEntity<ErrorResponse> handleNotIncludedMapException(NotIncludedMapException e) {
+    @ExceptionHandler(NotIncludedMapException.class)
+    public ResponseEntity<ErrorResponse> handleNotIncludedMapException(NotIncludedMapException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(AlreadyExistedEmailException.class)
-  public ResponseEntity<ErrorResponse> handleAlreadyExistedEmailException(
-      AlreadyExistedEmailException e) {
+    @ExceptionHandler(AlreadyExistedEmailException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyExistedEmailException(
+        AlreadyExistedEmailException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(NotExistsException.class)
-  public ResponseEntity<ErrorResponse> NotExistsEmailException(NotExistsException e) {
+    @ExceptionHandler(NotExistsException.class)
+    public ResponseEntity<ErrorResponse> NotExistsEmailException(NotExistsException e) {
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(NotMatchPasswordException.class)
-  public ResponseEntity<ErrorResponse> handleNotMatchPasswordException(
-      NotMatchPasswordException e) {
+    @ExceptionHandler(NotMatchPasswordException.class)
+    public ResponseEntity<ErrorResponse> handleNotMatchPasswordException(
+        NotMatchPasswordException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(NotMatchMemberException.class)
-  public ResponseEntity<ErrorResponse> handleNotMatchMemberException(NotMatchMemberException e) {
+    @ExceptionHandler(NotMatchMemberException.class)
+    public ResponseEntity<ErrorResponse> handleNotMatchMemberException(NotMatchMemberException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(WrongMapTypeException.class)
-  public ResponseEntity<ErrorResponse> handleWrongMapTypeException(WrongMapTypeException e) {
+    @ExceptionHandler(WrongMapTypeException.class)
+    public ResponseEntity<ErrorResponse> handleWrongMapTypeException(WrongMapTypeException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(WrongInputException.class)
-  public ResponseEntity<ErrorResponse> handleWrongInputException(WrongInputException e) {
+    @ExceptionHandler(WrongInputException.class)
+    public ResponseEntity<ErrorResponse> handleWrongInputException(WrongInputException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(AlreadyJoinedException.class)
-  public ResponseEntity<ErrorResponse> handleAlreadyJoinedException(AlreadyJoinedException e) {
+    @ExceptionHandler(AlreadyJoinedException.class)
+    public ResponseEntity<ErrorResponse> handleAlreadyJoinedException(AlreadyJoinedException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  @ExceptionHandler(NotAuthorizedOrExistException.class)
-  public ResponseEntity<ErrorResponse> handleNotAuthorizedOrExistException(
-      NotAuthorizedOrExistException e) {
+    @ExceptionHandler(NotAuthorizedOrExistException.class)
+    public ResponseEntity<ErrorResponse> handleNotAuthorizedOrExistException(
+        NotAuthorizedOrExistException e) {
 
-    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-        .body(new ErrorResponse(e.getMessage()));
-  }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(new ErrorResponse(e.getMessage()));
+    }
 
-  //아래 4가지는 기본적으로 설정된 에러
-  //Post시 body가 비어있거나 형식이 알맞지 않을 때
-  @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
-      HttpMessageNotReadableException e) {
+    //아래 4가지는 기본적으로 설정된 에러
+    //Post시 body가 비어있거나 형식이 알맞지 않을 때
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+        HttpMessageNotReadableException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
+    }
 
-  //Post시 body내의 argument와 controller에서 설정한 requestParam 내의 요소가 불일치
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
-      MethodArgumentNotValidException e) {
+    //Post시 body내의 argument와 controller에서 설정한 requestParam 내의 요소가 불일치
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
+    }
 
-  //요청시 queryString 값을 잘못입력하거나 입력안함
-  @ExceptionHandler(MissingServletRequestParameterException.class)
-  public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
-      MissingServletRequestParameterException e) {
+    //요청시 queryString 값을 잘못입력하거나 입력안함
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+        MissingServletRequestParameterException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
+    }
 
-  //요청시 queryString의 타입이 잘못됨
-  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-  public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
-      MethodArgumentTypeMismatchException e) {
+    //요청시 queryString의 타입이 잘못됨
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+        MethodArgumentTypeMismatchException e) {
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
-  }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse("요청사항중 일부 값이 잘못 설정되었습니다."));
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/error/exception/NotAuthorizedOrExistException.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/error/exception/NotAuthorizedOrExistException.java
@@ -1,7 +1,8 @@
 package foot.footprint.global.error.exception;
 
-public class NotAuthorizedOrExistException extends RuntimeException{
-  public NotAuthorizedOrExistException(String message) {
-    super(message);
-  }
+public class NotAuthorizedOrExistException extends RuntimeException {
+
+    public NotAuthorizedOrExistException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/error/exception/NotExistsException.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/error/exception/NotExistsException.java
@@ -1,7 +1,8 @@
 package foot.footprint.global.error.exception;
 
-public class NotExistsException extends RuntimeException{
-  public NotExistsException(String message) {
-    super(message);
-  }
+public class NotExistsException extends RuntimeException {
+
+    public NotExistsException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/error/exception/WrongInputException.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/error/exception/WrongInputException.java
@@ -1,7 +1,8 @@
 package foot.footprint.global.error.exception;
 
-public class WrongInputException extends RuntimeException{
-  public WrongInputException(String message) {
-    super(message);
-  }
+public class WrongInputException extends RuntimeException {
+
+    public WrongInputException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/error/exception/WrongMapTypeException.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/error/exception/WrongMapTypeException.java
@@ -2,7 +2,7 @@ package foot.footprint.global.error.exception;
 
 public class WrongMapTypeException extends RuntimeException {
 
-  public WrongMapTypeException(String message) {
-    super(message);
-  }
+    public WrongMapTypeException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/CookieAuthorizationRequestRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/CookieAuthorizationRequestRepository.java
@@ -10,45 +10,45 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class CookieAuthorizationRequestRepository implements AuthorizationRequestRepository {
 
-  public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
-  public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
-  private static final int COOKIE_EXPIRE_SECONDS = 180;
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int COOKIE_EXPIRE_SECONDS = 180;
 
-  @Override
-  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-    return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
-        .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
-        .orElse(null);
-  }
-
-  @Override
-  public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
-      HttpServletRequest request, HttpServletResponse response) {
-    if (authorizationRequest == null) {
-      CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-      CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-      return;
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtil.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map(cookie -> CookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class))
+            .orElse(null);
     }
 
-    CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
-        CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
-    String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+        HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
 
-    if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
-      CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin,
-          COOKIE_EXPIRE_SECONDS);
+        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            CookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin,
+                COOKIE_EXPIRE_SECONDS);
+        }
+
     }
 
-  }
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
 
-  @Override
-  public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
-    return this.loadAuthorizationRequest(request);
-  }
-
-  public void removeAuthorizationRequestCookies(HttpServletRequest request,
-      HttpServletResponse response) {
-    CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-    CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
-  }
+    public void removeAuthorizationRequestCookies(HttpServletRequest request,
+        HttpServletResponse response) {
+        CookieUtil.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtil.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/CookieUtil.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/CookieUtil.java
@@ -10,50 +10,50 @@ import java.util.Optional;
 
 public class CookieUtil {
 
-  public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
-    Cookie[] cookies = request.getCookies();
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
 
-    if (cookies != null && cookies.length > 0) {
-      for (Cookie cookie : cookies) {
-        if (cookie.getName().equals(name)) {
-          return Optional.of(cookie);
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
         }
-      }
+        return Optional.empty();
     }
-    return Optional.empty();
-  }
 
-  public static void addCookie(HttpServletResponse response, String name, String value,
-      int maxAge) {
-    Cookie cookie = new Cookie(name, value);
-    cookie.setPath("/");
-    cookie.setHttpOnly(true);
-    cookie.setMaxAge(maxAge);
-    response.addCookie(cookie);
-  }
+    public static void addCookie(HttpServletResponse response, String name, String value,
+        int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
 
-  public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
-      String name) {
-    Cookie[] cookies = request.getCookies();
-    if (cookies != null && cookies.length > 0) {
-      for (Cookie cookie : cookies) {
-        if (cookie.getName().equals(name)) {
-          cookie.setValue("");
-          cookie.setPath("/");
-          cookie.setMaxAge(0);
-          response.addCookie(cookie);
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+        String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
         }
-      }
     }
-  }
 
-  public static String serialize(Object object) {
-    return Base64.getUrlEncoder()
-        .encodeToString(SerializationUtils.serialize(object));
-  }
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+            .encodeToString(SerializationUtils.serialize(object));
+    }
 
-  public static <T> T deserialize(Cookie cookie, Class<T> cls) {
-    return cls.cast(SerializationUtils.deserialize(
-        Base64.getUrlDecoder().decode(cookie.getValue())));
-  }
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+            Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/JwtAccessDeniedHandler.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/JwtAccessDeniedHandler.java
@@ -12,9 +12,9 @@ import java.io.IOException;
 //사용자가 권한없는 요청시 403 Forbidden 처리(인가)
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
-  @Override
-  public void handle(HttpServletRequest request, HttpServletResponse response,
-      AccessDeniedException accessDeniedException) throws IOException, ServletException {
-    response.sendError(HttpServletResponse.SC_FORBIDDEN);
-  }
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/JwtAuthenticationEntryPoint.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/JwtAuthenticationEntryPoint.java
@@ -12,9 +12,10 @@ import java.io.IOException;
 //사용자가 인증없이 요청시 401 Unauthorized 처리(인증)
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-  @Override
-  public void commence(HttpServletRequest request, HttpServletResponse response,
-      AuthenticationException authException) throws IOException, ServletException {
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
-  }
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+            authException.getLocalizedMessage());
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/JwtAuthenticationFilter.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/JwtAuthenticationFilter.java
@@ -18,31 +18,31 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-  private final JwtTokenProvider tokenProvider;
+    private final JwtTokenProvider tokenProvider;
 
-  @Override
-  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-      FilterChain filterChain) throws ServletException, IOException {
-    String token = parseBearerToken(request);
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        String token = parseBearerToken(request);
 
-    // Validation Access Token
-    if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
-      Authentication authentication = tokenProvider.getAuthentication(token);
-      SecurityContextHolder.getContext().setAuthentication(authentication);
-      log.debug(authentication.getName() + "의 인증정보 저장");
-    } else {
-      log.debug("유효한 JWT 토큰이 없습니다.");
+        // Validation Access Token
+        if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug(authentication.getName() + "의 인증정보 저장");
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다.");
+        }
+
+        filterChain.doFilter(request, response);
     }
 
-    filterChain.doFilter(request, response);
-  }
+    private String parseBearerToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
 
-  private String parseBearerToken(HttpServletRequest request) {
-    String bearerToken = request.getHeader("Authorization");
-
-    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-      return bearerToken.substring(7);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
-    return null;
-  }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/JwtTokenProvider.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/JwtTokenProvider.java
@@ -27,102 +27,103 @@ import java.util.stream.Collectors;
 @Component
 public class JwtTokenProvider {
 
-  private final Key SECRET_KEY;
-  private final String COOKIE_REFRESH_TOKEN_KEY;
-  private final Long ACCESS_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60;        // 1hour
-  private final Long REFRESH_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60 * 24 * 7;    // 1week
-  private final String AUTHORITIES_KEY = "role";
+    private final Key SECRET_KEY;
+    private final String COOKIE_REFRESH_TOKEN_KEY;
+    private final Long ACCESS_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60;        // 1hour
+    private final Long REFRESH_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60 * 24 * 7;    // 1week
+    private final String AUTHORITIES_KEY = "role";
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  public JwtTokenProvider(@Value("${app.auth.tokenSecret}") String secretKey,
-      @Value("${app.auth.refreshCookieKey}") String cookieKey) {
-    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
-    this.SECRET_KEY = Keys.hmacShaKeyFor(keyBytes);
-    this.COOKIE_REFRESH_TOKEN_KEY = cookieKey;
-  }
-
-  public String createAccessToken(String memberId, Role role) {
-    Date now = new Date();
-    Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH);
-
-    return Jwts.builder()
-        .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
-        .setSubject(memberId)
-        .claim(AUTHORITIES_KEY, role)
-        .setIssuer("khds")
-        .setIssuedAt(now)
-        .setExpiration(validity)
-        .compact();
-  }
-
-  public void createRefreshToken(Authentication authentication, HttpServletResponse response) {
-    Date now = new Date();
-    Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_LENGTH);
-
-    String refreshToken = Jwts.builder()
-        .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
-        .setIssuer("khds")
-        .setIssuedAt(now)
-        .setExpiration(validity)
-        .compact();
-
-    saveRefreshToken(authentication, refreshToken);
-
-    ResponseCookie cookie = ResponseCookie.from(COOKIE_REFRESH_TOKEN_KEY, refreshToken)
-        .httpOnly(true)
-        .secure(true)
-        .sameSite("Lax")
-        .maxAge(REFRESH_TOKEN_EXPIRE_LENGTH / 1000)
-        .path("/")
-        .build();
-
-    response.addHeader("Set-Cookie", cookie.toString());
-  }
-
-  private void saveRefreshToken(Authentication authentication, String refreshToken) {
-    CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
-    Long id = Long.valueOf(user.getName());
-
-    memberRepository.updateRefreshToken(id, refreshToken);
-  }
-
-  // Access Token을 검사하고 얻은 정보로 Authentication 객체 생성
-  public Authentication getAuthentication(String accessToken) {
-    Claims claims = parseClaims(accessToken);
-
-    Collection<? extends GrantedAuthority> authorities =
-        Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-            .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
-
-    CustomUserDetails principal = new CustomUserDetails(Long.valueOf(claims.getSubject()), "",
-        authorities);
-
-    return new UsernamePasswordAuthenticationToken(principal, "", authorities);
-  }
-
-  public Boolean validateToken(String token) {
-    try {
-      Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(token);
-      return true;
-    } catch (ExpiredJwtException e) {
-      log.info("만료된 JWT 토큰입니다.");
-    } catch (UnsupportedJwtException e) {
-      log.info("지원되지 않는 JWT 토큰입니다.");
-    } catch (IllegalStateException e) {
-      log.info("JWT 토큰이 잘못되었습니다");
+    public JwtTokenProvider(@Value("${app.auth.tokenSecret}") String secretKey,
+        @Value("${app.auth.refreshCookieKey}") String cookieKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.SECRET_KEY = Keys.hmacShaKeyFor(keyBytes);
+        this.COOKIE_REFRESH_TOKEN_KEY = cookieKey;
     }
-    return false;
-  }
 
-  // Access Token 만료시 갱신때 사용할 정보를 얻기 위해 Claim 리턴
-  private Claims parseClaims(String accessToken) {
-    try {
-      return Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(accessToken)
-          .getBody();
-    } catch (ExpiredJwtException e) {
-      return e.getClaims();
+    public String createAccessToken(String memberId, Role role) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH);
+
+        return Jwts.builder()
+            .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
+            .setSubject(memberId)
+            .claim(AUTHORITIES_KEY, role)
+            .setIssuer("khds")
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .compact();
     }
-  }
+
+    public void createRefreshToken(Authentication authentication, HttpServletResponse response) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_LENGTH);
+
+        String refreshToken = Jwts.builder()
+            .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
+            .setIssuer("khds")
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .compact();
+
+        saveRefreshToken(authentication, refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_REFRESH_TOKEN_KEY, refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Lax")
+            .maxAge(REFRESH_TOKEN_EXPIRE_LENGTH / 1000)
+            .path("/")
+            .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    private void saveRefreshToken(Authentication authentication, String refreshToken) {
+        CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
+        Long id = Long.valueOf(user.getName());
+
+        memberRepository.updateRefreshToken(id, refreshToken);
+    }
+
+    // Access Token을 검사하고 얻은 정보로 Authentication 객체 생성
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+
+        CustomUserDetails principal = new CustomUserDetails(Long.valueOf(claims.getSubject()), "",
+            authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public Boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalStateException e) {
+            log.info("JWT 토큰이 잘못되었습니다");
+        }
+        return false;
+    }
+
+    // Access Token 만료시 갱신때 사용할 정보를 얻기 위해 Claim 리턴
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(SECRET_KEY).build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/OAuth2AuthenticationFailureHandler.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/OAuth2AuthenticationFailureHandler.java
@@ -17,23 +17,23 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-  private final CookieAuthorizationRequestRepository authorizationRequestRepository;
+    private final CookieAuthorizationRequestRepository authorizationRequestRepository;
 
-  //OAuth2 로그인 실패시 호출되는 Handler
-  //인증요청시 생성된 쿠키들을 삭제하고 error를 담아 보낸다
-  @Override
-  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-      AuthenticationException exception) throws IOException, ServletException {
-    String targetUrl = CookieUtil.getCookie(request,
-            CookieAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME)
-        .map(Cookie::getValue)
-        .orElse("/");
+    //OAuth2 로그인 실패시 호출되는 Handler
+    //인증요청시 생성된 쿠키들을 삭제하고 error를 담아 보낸다
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException, ServletException {
+        String targetUrl = CookieUtil.getCookie(request,
+                CookieAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME)
+            .map(Cookie::getValue)
+            .orElse("/");
 
-    targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-        .queryParam("error", exception.getLocalizedMessage())
-        .build().toUriString();
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+            .queryParam("error", exception.getLocalizedMessage())
+            .build().toUriString();
 
-    authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
-    getRedirectStrategy().sendRedirect(request, response, targetUrl);
-  }
+        authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/exception/NotAuthorizedRedirectUriException.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/exception/NotAuthorizedRedirectUriException.java
@@ -2,7 +2,7 @@ package foot.footprint.global.security.exception;
 
 public class NotAuthorizedRedirectUriException extends RuntimeException {
 
-  public NotAuthorizedRedirectUriException(String message) {
-    super(message);
-  }
+    public NotAuthorizedRedirectUriException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/exception/OAuth2AuthenticationProcessingException.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/exception/OAuth2AuthenticationProcessingException.java
@@ -4,7 +4,7 @@ import org.springframework.security.core.AuthenticationException;
 
 public class OAuth2AuthenticationProcessingException extends AuthenticationException {
 
-  public OAuth2AuthenticationProcessingException(String message) {
-    super(message);
-  }
+    public OAuth2AuthenticationProcessingException(String message) {
+        super(message);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/service/CustomOAuth2UserService.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/service/CustomOAuth2UserService.java
@@ -22,53 +22,53 @@ import java.util.*;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-  private static final String DUMMY_PASSWORD = "무의미한 패스워드";
+    private static final String DUMMY_PASSWORD = "무의미한 패스워드";
 
-  private final PasswordEncoder passwordEncoder;
-  private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
 
-  @Override
-  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-    OAuth2UserService delegate = new DefaultOAuth2UserService();
-    OAuth2User oAuth2User = delegate.loadUser(
-        userRequest); // OAuth 서비스(github, google, naver)에서 가져온 유저 정보를 담고있음
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(
+            userRequest); // OAuth 서비스(github, google, naver)에서 가져온 유저 정보를 담고있음
 
-    String registrationId = userRequest.getClientRegistration()
-        .getRegistrationId(); // OAuth 서비스 이름(ex. github, naver, google)
-    String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
-        .getUserInfoEndpoint().getUserNameAttributeName(); // OAuth 로그인 시 키(pk)가 되는 값
-    Map<String, Object> attributes = oAuth2User.getAttributes(); // OAuth 서비스의 유저 정보들
+        String registrationId = userRequest.getClientRegistration()
+            .getRegistrationId(); // OAuth 서비스 이름(ex. github, naver, google)
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+            .getUserInfoEndpoint().getUserNameAttributeName(); // OAuth 로그인 시 키(pk)가 되는 값
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // OAuth 서비스의 유저 정보들
 
-    // registrationId에 따라 유저 정보를 통해 공통된 UserProfile 객체로 만들어 줌
-    UserProfile userProfile = OAuthAttributes.extract(registrationId, attributes);
-    if (Objects.isNull(userProfile.getEmail()) || userProfile.getEmail().isEmpty()) {
-      throw new OAuth2AuthenticationProcessingException("해당하는 이메일이 존재하지 않습니다.");
-    }
-    Member member = saveOrUpdate(userProfile, registrationId);  // DB에 저장
+        // registrationId에 따라 유저 정보를 통해 공통된 UserProfile 객체로 만들어 줌
+        UserProfile userProfile = OAuthAttributes.extract(registrationId, attributes);
+        if (Objects.isNull(userProfile.getEmail()) || userProfile.getEmail().isEmpty()) {
+            throw new OAuth2AuthenticationProcessingException("해당하는 이메일이 존재하지 않습니다.");
+        }
+        Member member = saveOrUpdate(userProfile, registrationId);  // DB에 저장
 
-    return CustomUserDetails.create(member, oAuth2User.getAttributes());
-  }
-
-  private Member saveOrUpdate(UserProfile userProfile, String registrationId) {
-    Optional<Member> userOptional = memberRepository.findByEmail(userProfile.getEmail());
-    Member member;
-    if (userOptional.isPresent()) {
-      member = userOptional.get();
-    } else {
-      Date date = new Date();
-      member = Member.builder()
-          .nick_name(userProfile.getName())
-          .email(userProfile.getEmail())
-          .provider(AuthProvider.valueOf(registrationId))
-          .password(passwordEncoder.encode(DUMMY_PASSWORD))
-          .provider_id(userProfile.getProviderId())
-          .image_url(userProfile.getImageUrl())
-          .join_date(date)
-          .role(Role.USER)
-          .build();
-      memberRepository.saveMember(member);
+        return CustomUserDetails.create(member, oAuth2User.getAttributes());
     }
 
-    return member;
-  }
+    private Member saveOrUpdate(UserProfile userProfile, String registrationId) {
+        Optional<Member> userOptional = memberRepository.findByEmail(userProfile.getEmail());
+        Member member;
+        if (userOptional.isPresent()) {
+            member = userOptional.get();
+        } else {
+            Date date = new Date();
+            member = Member.builder()
+                .nick_name(userProfile.getName())
+                .email(userProfile.getEmail())
+                .provider(AuthProvider.valueOf(registrationId))
+                .password(passwordEncoder.encode(DUMMY_PASSWORD))
+                .provider_id(userProfile.getProviderId())
+                .image_url(userProfile.getImageUrl())
+                .join_date(date)
+                .role(Role.USER)
+                .build();
+            memberRepository.saveMember(member);
+        }
+
+        return member;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/user/CustomUserDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/user/CustomUserDetails.java
@@ -12,86 +12,87 @@ import java.util.Map;
 
 public class CustomUserDetails implements UserDetails, OAuth2User {
 
-  private Long id;
-  private String email;
-  private Collection<? extends GrantedAuthority> authorities;
-  private Map<String, Object> attributes;
+    private Long id;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
 
-  public CustomUserDetails(Long id, String email,
-      Collection<? extends GrantedAuthority> authorities) {
-    this.id = id;
-    this.email = email;
-    this.authorities = authorities;
-  }
+    public CustomUserDetails(Long id, String email,
+        Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.authorities = authorities;
+    }
 
-  public static CustomUserDetails create(Member member) {
-    List<GrantedAuthority> authorities = Collections.
-        singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    public static CustomUserDetails create(Member member) {
+        List<GrantedAuthority> authorities = Collections.
+            singletonList(new SimpleGrantedAuthority("ROLE_USER"));
 
-    return new CustomUserDetails(
-        member.getId(),
-        member.getEmail(),
-        authorities
-    );
-  }
+        return new CustomUserDetails(
+            member.getId(),
+            member.getEmail(),
+            authorities
+        );
+    }
 
-  public static CustomUserDetails create(Member member, Map<String, Object> attributes) {
-    CustomUserDetails userDetails = CustomUserDetails.create(member);
-    userDetails.setAttributes(attributes);
-    return userDetails;
-  }
+    public static CustomUserDetails create(Member member, Map<String, Object> attributes) {
+        CustomUserDetails userDetails = CustomUserDetails.create(member);
+        userDetails.setAttributes(attributes);
+        return userDetails;
+    }
 
-  public Long getId(){
-    return this.id;
-  }
-  // UserDetail Override
-  @Override
-  public Collection<? extends GrantedAuthority> getAuthorities() {
-    return authorities;
-  }
+    public Long getId() {
+        return this.id;
+    }
 
-  @Override
-  public String getUsername() {
-    return email;
-  }
+    // UserDetail Override
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
 
-  @Override
-  public String getPassword() {
-    return null;
-  }
+    @Override
+    public String getUsername() {
+        return email;
+    }
 
-  @Override
-  public boolean isAccountNonExpired() {
-    return true;
-  }
+    @Override
+    public String getPassword() {
+        return null;
+    }
 
-  @Override
-  public boolean isAccountNonLocked() {
-    return true;
-  }
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
 
-  @Override
-  public boolean isCredentialsNonExpired() {
-    return true;
-  }
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
 
-  @Override
-  public boolean isEnabled() {
-    return true;
-  }
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
 
-  // OAuth2User Override
-  @Override
-  public String getName() {
-    return String.valueOf(id);
-  }
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 
-  @Override
-  public Map<String, Object> getAttributes() {
-    return attributes;
-  }
+    // OAuth2User Override
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
 
-  public void setAttributes(Map<String, Object> attributes) {
-    this.attributes = attributes;
-  }
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/user/OAuthAttributes.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/user/OAuthAttributes.java
@@ -5,37 +5,37 @@ import java.util.Map;
 import java.util.function.Function;
 
 public enum OAuthAttributes {
-  GOOGLE("google", (attributes) -> {
-    return new UserProfile(
-        String.valueOf(attributes.get("sub")),
-        (String) attributes.get("name"),
-        (String) attributes.get("email"),
-        (String) attributes.get("picture")
-    );
-  }),
-  NAVER("naver", (attributes) -> {
-    Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-    return new UserProfile(
-        (String) response.get("id"),
-        (String) response.get("name"),
-        (String) response.get("email"),
-        (String) response.get("profile_image")
-    );
-  });
+    GOOGLE("google", (attributes) -> {
+        return new UserProfile(
+            String.valueOf(attributes.get("sub")),
+            (String) attributes.get("name"),
+            (String) attributes.get("email"),
+            (String) attributes.get("picture")
+        );
+    }),
+    NAVER("naver", (attributes) -> {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return new UserProfile(
+            (String) response.get("id"),
+            (String) response.get("name"),
+            (String) response.get("email"),
+            (String) response.get("profile_image")
+        );
+    });
 
-  private final String registrationId;
-  private final Function<Map<String, Object>, UserProfile> of;
+    private final String registrationId;
+    private final Function<Map<String, Object>, UserProfile> of;
 
-  OAuthAttributes(String registrationId, Function<Map<String, Object>, UserProfile> of) {
-    this.registrationId = registrationId;
-    this.of = of;
-  }
+    OAuthAttributes(String registrationId, Function<Map<String, Object>, UserProfile> of) {
+        this.registrationId = registrationId;
+        this.of = of;
+    }
 
-  public static UserProfile extract(String registrationId, Map<String, Object> attributes) {
-    return Arrays.stream(values())
-        .filter(provider -> registrationId.equals(provider.registrationId))
-        .findFirst()
-        .orElseThrow(IllegalArgumentException::new)
-        .of.apply(attributes);
-  }
+    public static UserProfile extract(String registrationId, Map<String, Object> attributes) {
+        return Arrays.stream(values())
+            .filter(provider -> registrationId.equals(provider.registrationId))
+            .findFirst()
+            .orElseThrow(IllegalArgumentException::new)
+            .of.apply(attributes);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/security/user/UserProfile.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/security/user/UserProfile.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Getter
 public class UserProfile {
 
-  private final String providerId;
-  private final String name;
-  private final String email;
-  private final String imageUrl;
+    private final String providerId;
+    private final String name;
+    private final String email;
+    private final String imageUrl;
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/typeHandler/CodeEnum.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/typeHandler/CodeEnum.java
@@ -2,5 +2,5 @@ package foot.footprint.global.typeHandler;
 
 public interface CodeEnum {
 
-  String getCode();
+    String getCode();
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/typeHandler/CodeEnumTypeHandler.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/typeHandler/CodeEnumTypeHandler.java
@@ -12,38 +12,38 @@ import java.util.EnumSet;
 public abstract class CodeEnumTypeHandler<E extends Enum<E> & CodeEnum> implements
     TypeHandler<CodeEnum> {
 
-  private Class<E> type;
+    private Class<E> type;
 
-  public CodeEnumTypeHandler(Class<E> type) {
-    this.type = type;
-  }
+    public CodeEnumTypeHandler(Class<E> type) {
+        this.type = type;
+    }
 
-  @Override
-  public void setParameter(PreparedStatement ps, int i, CodeEnum parameter, JdbcType jdbcType)
-      throws SQLException {
-    ps.setString(i, parameter.getCode());
-  }
+    @Override
+    public void setParameter(PreparedStatement ps, int i, CodeEnum parameter, JdbcType jdbcType)
+        throws SQLException {
+        ps.setString(i, parameter.getCode());
+    }
 
-  @Override
-  public CodeEnum getResult(ResultSet rs, String columnName) throws SQLException {
-    return getCodeEnum(rs.getString(columnName));
-  }
+    @Override
+    public CodeEnum getResult(ResultSet rs, String columnName) throws SQLException {
+        return getCodeEnum(rs.getString(columnName));
+    }
 
-  @Override
-  public CodeEnum getResult(ResultSet rs, int columnIndex) throws SQLException {
-    return getCodeEnum(rs.getString(columnIndex));
-  }
+    @Override
+    public CodeEnum getResult(ResultSet rs, int columnIndex) throws SQLException {
+        return getCodeEnum(rs.getString(columnIndex));
+    }
 
-  @Override
-  public CodeEnum getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    return getCodeEnum(cs.getString(columnIndex));
-  }
+    @Override
+    public CodeEnum getResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return getCodeEnum(cs.getString(columnIndex));
+    }
 
-  private CodeEnum getCodeEnum(String code) {
-    return EnumSet.allOf(type)
-        .stream()
-        .filter(value -> value.getCode().equals(code))
-        .findFirst()
-        .orElseGet(null);
-  }
+    private CodeEnum getCodeEnum(String code) {
+        return EnumSet.allOf(type)
+            .stream()
+            .filter(value -> value.getCode().equals(code))
+            .findFirst()
+            .orElseGet(null);
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/global/util/ValidateIsMine.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/util/ValidateIsMine.java
@@ -6,16 +6,16 @@ import foot.footprint.global.error.exception.NotAuthorizedOrExistException;
 
 public class ValidateIsMine {
 
-  public static void validateArticleIsMine(Long writerId, Long memberId) {
-    if (writerId != memberId) {
-      throw new NotMatchMemberException("해당글에 접근할 권한이 없습니다.");
+    public static void validateArticleIsMine(Long writerId, Long memberId) {
+        if (writerId != memberId) {
+            throw new NotMatchMemberException("해당글에 접근할 권한이 없습니다.");
+        }
     }
-  }
 
-  public static void validateInMyGroup(Long articleId, Long memberId,
-      ArticleGroupRepository articleGroupRepository) {
-    if (!articleGroupRepository.existsArticleInMyGroup(articleId, memberId)) {
-      throw new NotAuthorizedOrExistException("해당글에 접근할 권한이 없습니다.");
+    public static void validateInMyGroup(Long articleId, Long memberId,
+        ArticleGroupRepository articleGroupRepository) {
+        if (!articleGroupRepository.existsArticleInMyGroup(articleId, memberId)) {
+            throw new NotAuthorizedOrExistException("해당글에 접근할 권한이 없습니다.");
+        }
     }
-  }
 }

--- a/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
@@ -8,4 +8,32 @@
     ) VALUES (#{email}, #{image_url}, #{join_date}, #{nick_name}, #{password}, #{provider},
     #{provider_id}, #{role})
   </insert>
+  <select id="findMyPageDetails" resultMap="myPageDetails">
+    SELECT m.id as memberId, m.image_url as imageUrl, m.nick_name as nickName,
+    m.email as email, m.join_date as visitDate, a.id as articleId, a.title as title,
+    a.create_date as createDate, count(al.id) as totalLikes, count(c.id) as totalComments,
+    g.id as groupId, g.name as name
+    FROM member m LEFT JOIN article a ON m.id = a.member_id
+    LEFT JOIN comment c ON a.id = c.article_id Left JOIN article_like al ON a.id = al.article_id
+    LEFT JOIN member_group mg ON m.id = mg.member_id LEFT JOIN group_table g ON mg.group_id = g.id
+    WHERE m.id = #{memberId} GROUP BY a.id
+  </select>
+  <resultMap id="myPageDetails" type="MyPageResponse">
+    <id property="memberId" column="memberId"/>
+    <result property="imageUrl" column="imageUrl"/>
+    <result property="nickName" column="nickName"/>
+    <result property="email" column="email"/>
+    <result property="visitDate" column="visitDate"/>
+    <collection property="myArticles" ofType="foot.footprint.domain.member.dto.MyArticleResponse">
+      <id property="articleId" column="articleId"/>
+      <result property="title" column="title"/>
+      <result property="createDate" column="createDate"/>
+      <result property="totalLikes" column="totalLikes"/>
+      <result property="totalComments" column="totalComments"/>
+    </collection>
+    <collection property="myGroups" ofType="foot.footprint.domain.group.dto.GroupSummaryResponse">
+      <id property="groupId" column="groupId"/>
+      <result property="name" column="name"/>
+    </collection>
+  </resultMap>
 </mapper>

--- a/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
@@ -11,10 +11,10 @@
   <select id="findMyPageDetails" resultMap="myPageDetails">
     SELECT m.id as memberId, m.image_url as imageUrl, m.nick_name as nickName,
     m.email as email, m.join_date as visitDate,
-    a.id as articleId, a.title as title, a.create_date as createDate, count(al.id) as totalLikes,
-    count(c.id) as totalComments, g.id as groupId, g.name as name
+    a.id as articleId, a.title as title, a.create_date as createDate, count(distinct al.id) as totalLikes,
+    count(distinct c.id) as totalComments, g.id as groupId, g.name as name
     FROM member m LEFT JOIN article a ON m.id = a.member_id LEFT JOIN comment c ON a.id = c.article_id
-    left JOIN article_like al ON a.id = al.article_id LEFT JOIN member_group mg ON m.id = mg.member_id
+    LEFT JOIN article_like al ON a.id = al.article_id LEFT JOIN member_group mg ON m.id = mg.member_id
     LEFT JOIN group_table g ON mg.group_id = g.id WHERE m.id = #{memberId} GROUP BY a.id
   </select>
   <resultMap id="myPageDetails" type="MyPageResponse">

--- a/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
@@ -8,16 +8,14 @@
     ) VALUES (#{email}, #{image_url}, #{join_date}, #{nick_name}, #{password}, #{provider},
     #{provider_id}, #{role})
   </insert>
-  <!--  member 정보, myArticleList, MyGroupList를 select 함. myGroupList는 두번의 조인을 피하려고 subQuery 사용-->
   <select id="findMyPageDetails" resultMap="myPageDetails">
     SELECT m.id as memberId, m.image_url as imageUrl, m.nick_name as nickName,
-    m.email as email, m.join_date as visitDate, a.id as articleId, a.title as title,
-    a.create_date as createDate, count(al.id) as totalLikes, count(c.id) as totalComments,
-    (SELECT g.id as groupId, g.name as name FROM group_table g
-    LEFT JOIN member_group mg ON g.id = mg.group_id WHERE mg.member_id = #{memberId}),
-    FROM member m LEFT JOIN article a ON m.id = a.member_id
-    LEFT JOIN comment c ON a.id = c.article_id Left JOIN article_like al ON a.id = al.article_id
-    WHERE m.id = #{memberId} GROUP BY a.id
+    m.email as email, m.join_date as visitDate,
+    a.id as articleId, a.title as title, a.create_date as createDate, count(al.id) as totalLikes,
+    count(c.id) as totalComments, g.id as groupId, g.name as name
+    FROM member m LEFT JOIN article a ON m.id = a.member_id LEFT JOIN comment c ON a.id = c.article_id
+    left JOIN article_like al ON a.id = al.article_id LEFT JOIN member_group mg ON m.id = mg.member_id
+    LEFT JOIN group_table g ON mg.group_id = g.id WHERE m.id = #{memberId} GROUP BY a.id
   </select>
   <resultMap id="myPageDetails" type="MyPageResponse">
     <id property="memberId" column="memberId"/>
@@ -25,14 +23,16 @@
     <result property="nickName" column="nickName"/>
     <result property="email" column="email"/>
     <result property="visitDate" column="visitDate"/>
-    <collection property="myArticles" ofType="foot.footprint.domain.member.dto.MyArticleResponse">
+    <collection property="myArticles" notNullColumn="articleId"
+      ofType="foot.footprint.domain.member.dto.MyArticleResponse">
       <id property="articleId" column="articleId"/>
       <result property="title" column="title"/>
       <result property="createDate" column="createDate"/>
       <result property="totalLikes" column="totalLikes"/>
       <result property="totalComments" column="totalComments"/>
     </collection>
-    <collection property="myGroups" ofType="foot.footprint.domain.group.dto.GroupSummaryResponse">
+    <collection property="myGroups" notNullColumn="groupId"
+      ofType="foot.footprint.domain.group.dto.GroupSummaryResponse">
       <id property="groupId" column="groupId"/>
       <result property="name" column="name"/>
     </collection>

--- a/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
@@ -8,14 +8,15 @@
     ) VALUES (#{email}, #{image_url}, #{join_date}, #{nick_name}, #{password}, #{provider},
     #{provider_id}, #{role})
   </insert>
+  <!--  member 정보, myArticleList, MyGroupList를 select 함. myGroupList는 두번의 조인을 피하려고 subQuery 사용-->
   <select id="findMyPageDetails" resultMap="myPageDetails">
     SELECT m.id as memberId, m.image_url as imageUrl, m.nick_name as nickName,
     m.email as email, m.join_date as visitDate, a.id as articleId, a.title as title,
     a.create_date as createDate, count(al.id) as totalLikes, count(c.id) as totalComments,
-    g.id as groupId, g.name as name
+    (SELECT g.id as groupId, g.name as name FROM group_table g
+    LEFT JOIN member_group mg ON g.id = mg.group_id WHERE mg.member_id = #{memberId}),
     FROM member m LEFT JOIN article a ON m.id = a.member_id
     LEFT JOIN comment c ON a.id = c.article_id Left JOIN article_like al ON a.id = al.article_id
-    LEFT JOIN member_group mg ON m.id = mg.member_id LEFT JOIN group_table g ON mg.group_id = g.id
     WHERE m.id = #{memberId} GROUP BY a.id
   </select>
   <resultMap id="myPageDetails" type="MyPageResponse">

--- a/backend/footprint/src/test/java/foot/footprint/FootprintApplicationTests.java
+++ b/backend/footprint/src/test/java/foot/footprint/FootprintApplicationTests.java
@@ -6,7 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class FootprintApplicationTests {
 
-  @Test
-  void contextLoads() {
-  }
+    @Test
+    void contextLoads() {
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
@@ -21,50 +21,50 @@ import org.springframework.test.context.junit4.SpringRunner;
 @Sql(value = "/init-table.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class RepositoryTest {
 
-  protected Member buildMember() {
-    return Member.builder()
-        .nick_name("nickName")
-        .email("email")
-        .provider(AuthProvider.google)
-        .password("password")
-        .provider_id("test")
-        .image_url(null)
-        .join_date(new Date())
-        .role(Role.USER)
-        .build();
-  }
+    protected Member buildMember() {
+        return Member.builder()
+            .nick_name("nickName")
+            .email("email")
+            .provider(AuthProvider.google)
+            .password("password")
+            .provider_id("test")
+            .image_url(null)
+            .join_date(new Date())
+            .role(Role.USER)
+            .build();
+    }
 
-  protected Article buildArticle(Long memberId) {
-    return Article.builder()
-        .content("test")
-        .latitude(10.0)
-        .longitude(10.0)
-        .public_map(true)
-        .private_map(true)
-        .title("test")
-        .create_date(new Date())
-        .member_id(memberId).build();
-  }
+    protected Article buildArticle(Long memberId) {
+        return Article.builder()
+            .content("test")
+            .latitude(10.0)
+            .longitude(10.0)
+            .public_map(true)
+            .private_map(true)
+            .title("test")
+            .create_date(new Date())
+            .member_id(memberId).build();
+    }
 
-  protected ArticleLike buildArticleLike(Long memberId, Long articleId) {
-    return ArticleLike.builder()
-        .member_id(memberId)
-        .article_id(articleId).build();
-  }
+    protected ArticleLike buildArticleLike(Long memberId, Long articleId) {
+        return ArticleLike.builder()
+            .member_id(memberId)
+            .article_id(articleId).build();
+    }
 
-  protected Comment buildComment(Long ownerId, Long articleId) {
-    return Comment.builder()
-        .content("아무내용")
-        .article_id(articleId)
-        .member_id(ownerId)
-        .create_date(new Date()).build();
-  }
+    protected Comment buildComment(Long ownerId, Long articleId) {
+        return Comment.builder()
+            .content("아무내용")
+            .article_id(articleId)
+            .member_id(ownerId)
+            .create_date(new Date()).build();
+    }
 
-  protected Group buildGroup(Long ownerId) {
-    return Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .invitation_code("testCode")
-        .owner_id(ownerId).build();
-  }
+    protected Group buildGroup(Long ownerId) {
+        return Group.builder()
+            .create_date(new Date())
+            .name("test_group")
+            .invitation_code("testCode")
+            .owner_id(ownerId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
@@ -4,6 +4,7 @@ import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.articleLike.domain.ArticleLike;
 import foot.footprint.domain.comment.domain.Comment;
 import foot.footprint.domain.group.domain.Group;
+import foot.footprint.domain.group.domain.MemberGroup;
 import foot.footprint.domain.member.domain.AuthProvider;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.domain.member.domain.Role;
@@ -66,5 +67,13 @@ public class RepositoryTest {
             .name("test_group")
             .invitation_code("testCode")
             .owner_id(ownerId).build();
+    }
+
+    protected MemberGroup buildMemberGroup(Long groupId, Long memberId) {
+        return MemberGroup.builder()
+            .create_date(new Date())
+            .group_id(groupId)
+            .member_id(memberId)
+            .important(true).build();
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/CreateArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/CreateArticleRepositoryTest.java
@@ -12,29 +12,29 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class CreateArticleRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private CreateArticleRepository articleRepository;
+    @Autowired
+    private CreateArticleRepository articleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Test
-  public void saveArticle() {
-    //given
-    Long memberId = saveOne();
-    Article article = buildArticle(memberId);
+    @Test
+    public void saveArticle() {
+        //given
+        Long memberId = saveOne();
+        Article article = buildArticle(memberId);
 
-    //when & then
-    assertThat(article.getId()).isNull();
-    articleRepository.saveArticle(article);
+        //when & then
+        assertThat(article.getId()).isNull();
+        articleRepository.saveArticle(article);
 
-    //then
-    assertThat(article.getId()).isNotNull();
-  }
+        //then
+        assertThat(article.getId()).isNotNull();
+    }
 
-  private Long saveOne() {
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    return member.getId();
-  }
+    private Long saveOne() {
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        return member.getId();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/DeleteArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/DeleteArticleRepositoryTest.java
@@ -17,52 +17,52 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class DeleteArticleRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private DeleteArticleRepository deleteArticleRepository;
+    @Autowired
+    private DeleteArticleRepository deleteArticleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private FindArticleRepository findArticleRepository;
+    @Autowired
+    private FindArticleRepository findArticleRepository;
 
-  @Test
-  public void deleteArticle() {
-    //given
-    Long memberId = 1L;
-    Long anotherId = 2L;
-    Article createdArticle = setUp(memberId);
+    @Test
+    public void deleteArticle() {
+        //given
+        Long memberId = 1L;
+        Long anotherId = 2L;
+        Article createdArticle = setUp(memberId);
 
-    //when & then
-    assertThat(deleteArticleRepository.deleteById(createdArticle.getId(), anotherId))
-        .isEqualTo(0);
-    assertThat(deleteArticleRepository.deleteById(createdArticle.getId(), memberId))
-        .isEqualTo(1);
-    assertThat(findArticleRepository.findById(createdArticle.getId())).isEmpty();
-  }
+        //when & then
+        assertThat(deleteArticleRepository.deleteById(createdArticle.getId(), anotherId))
+            .isEqualTo(0);
+        assertThat(deleteArticleRepository.deleteById(createdArticle.getId(), memberId))
+            .isEqualTo(1);
+        assertThat(findArticleRepository.findById(createdArticle.getId())).isEmpty();
+    }
 
-  private Article setUp(Long memberId) {
-    Member member = buildMember(memberId);
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    return article;
-  }
+    private Article setUp(Long memberId) {
+        Member member = buildMember(memberId);
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        return article;
+    }
 
-  private Member buildMember(Long memberId) {
-    return Member.builder()
-        .id(memberId)
-        .nick_name("nickName")
-        .email("email")
-        .provider(AuthProvider.google)
-        .password("password")
-        .provider_id("test")
-        .image_url(null)
-        .join_date(new Date())
-        .role(Role.USER)
-        .build();
-  }
+    private Member buildMember(Long memberId) {
+        return Member.builder()
+            .id(memberId)
+            .nick_name("nickName")
+            .email("email")
+            .provider(AuthProvider.google)
+            .password("password")
+            .provider_id("test")
+            .image_url(null)
+            .join_date(new Date())
+            .role(Role.USER)
+            .build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/EditArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/EditArticleRepositoryTest.java
@@ -17,54 +17,54 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class EditArticleRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private EditArticleRepository editArticleRepository;
+    @Autowired
+    private EditArticleRepository editArticleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private FindArticleRepository findArticleRepository;
+    @Autowired
+    private FindArticleRepository findArticleRepository;
 
-  @Test
-  public void editArticle() {
-    //given
-    Long memberId = 1L;
-    Long anotherId = 2L;
-    Article article = setUp(memberId);
-    String newContent = "수정된 내용";
+    @Test
+    public void editArticle() {
+        //given
+        Long memberId = 1L;
+        Long anotherId = 2L;
+        Article article = setUp(memberId);
+        String newContent = "수정된 내용";
 
-    //when & then
-    assertThat(editArticleRepository.editArticle(article.getId(), anotherId, newContent))
-        .isEqualTo(0);
-    assertThat(editArticleRepository.editArticle(article.getId(), memberId, newContent))
-        .isEqualTo(1);
-    assertThat(findArticleRepository.findById(article.getId()).get().getContent())
-        .isEqualTo(newContent);
-  }
+        //when & then
+        assertThat(editArticleRepository.editArticle(article.getId(), anotherId, newContent))
+            .isEqualTo(0);
+        assertThat(editArticleRepository.editArticle(article.getId(), memberId, newContent))
+            .isEqualTo(1);
+        assertThat(findArticleRepository.findById(article.getId()).get().getContent())
+            .isEqualTo(newContent);
+    }
 
-  private Article setUp(Long memberId) {
-    Member member = buildMember(memberId);
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    return article;
-  }
+    private Article setUp(Long memberId) {
+        Member member = buildMember(memberId);
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        return article;
+    }
 
-  private Member buildMember(Long memberId) {
-    return Member.builder()
-        .id(memberId)
-        .nick_name("nickName")
-        .email("email")
-        .provider(AuthProvider.google)
-        .password("password")
-        .provider_id("test")
-        .image_url(null)
-        .join_date(new Date())
-        .role(Role.USER)
-        .build();
-  }
+    private Member buildMember(Long memberId) {
+        return Member.builder()
+            .id(memberId)
+            .nick_name("nickName")
+            .email("email")
+            .provider(AuthProvider.google)
+            .password("password")
+            .provider_id("test")
+            .image_url(null)
+            .join_date(new Date())
+            .role(Role.USER)
+            .build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -27,148 +27,148 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FIndArticleRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private FindArticleRepository findArticleRepository;
+    @Autowired
+    private FindArticleRepository findArticleRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private GroupRepository groupRepository;
+    @Autowired
+    private GroupRepository groupRepository;
 
-  @Autowired
-  private ArticleGroupRepository articleGroupRepository;
+    @Autowired
+    private ArticleGroupRepository articleGroupRepository;
 
-  @Autowired
-  private ArticleLikeRepository articleLikeRepository;
+    @Autowired
+    private ArticleLikeRepository articleLikeRepository;
 
-  @Test
-  public void findArticlesTest() {
-    //given
-    saveArticle(10.0, 10.0, true, false);
-    saveArticle(35.0, 125.0, false, true);
+    @Test
+    public void findArticlesTest() {
+        //given
+        saveArticle(10.0, 10.0, true, false);
+        saveArticle(35.0, 125.0, false, true);
 
-    //when
-    //publicMapArticles
-    List<Article> articlesN = findArticleRepository.findArticles(
-        null,
-        new LocationRange(
-            new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0))
-    );
-    //publicMapArticles, but private 글
-    List<Article> articlesN2 = findArticleRepository.findArticles(
-        1L,
-        new LocationRange(
-            new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0))
-    );
-    //privateMapArticles 다른 유저
-    List<Article> articles1 = findArticleRepository.findArticles(
-        1L,
-        new LocationRange(
-            new ArticleRangeRequest(35.0, 5.0, 125.0, 5.0))
-    );
-    //privateMapArticles 해당 유저
-    List<Article> articles2 = findArticleRepository.findArticles(
-        2L,
-        new LocationRange(
-            new ArticleRangeRequest(35.0, 5.0, 125.0, 5.0))
-    );
-    //publicMapArticles 전체지도 but privateArticle만 존재
-    List<Article> articles3 = findArticleRepository.findArticles(
-        null,
-        new LocationRange(
-            new ArticleRangeRequest(35.0, 5.0, 125.0, 5.0))
-    );
-    //then
-    assertThat(articlesN).hasSize(1);
-    assertThat(articlesN2).hasSize(0);
-    assertThat(articles1).hasSize(0);
-    assertThat(articles2).hasSize(1);
-    assertThat(articles3).hasSize(0);
-  }
+        //when
+        //publicMapArticles
+        List<Article> articlesN = findArticleRepository.findArticles(
+            null,
+            new LocationRange(
+                new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0))
+        );
+        //publicMapArticles, but private 글
+        List<Article> articlesN2 = findArticleRepository.findArticles(
+            1L,
+            new LocationRange(
+                new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0))
+        );
+        //privateMapArticles 다른 유저
+        List<Article> articles1 = findArticleRepository.findArticles(
+            1L,
+            new LocationRange(
+                new ArticleRangeRequest(35.0, 5.0, 125.0, 5.0))
+        );
+        //privateMapArticles 해당 유저
+        List<Article> articles2 = findArticleRepository.findArticles(
+            2L,
+            new LocationRange(
+                new ArticleRangeRequest(35.0, 5.0, 125.0, 5.0))
+        );
+        //publicMapArticles 전체지도 but privateArticle만 존재
+        List<Article> articles3 = findArticleRepository.findArticles(
+            null,
+            new LocationRange(
+                new ArticleRangeRequest(35.0, 5.0, 125.0, 5.0))
+        );
+        //then
+        assertThat(articlesN).hasSize(1);
+        assertThat(articlesN2).hasSize(0);
+        assertThat(articles1).hasSize(0);
+        assertThat(articles2).hasSize(1);
+        assertThat(articles3).hasSize(0);
+    }
 
-  @Test
-  public void findArticlesByGroupTest() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    Group group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-    ArticleGroup articleGroup = ArticleGroup.createArticleGroup(group.getId(), article.getId());
-    List<ArticleGroup> articleGroups = new ArrayList<>();
-    articleGroups.add(articleGroup);
-    articleGroupRepository.saveArticleGroupList(articleGroups);
+    @Test
+    public void findArticlesByGroupTest() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        ArticleGroup articleGroup = ArticleGroup.createArticleGroup(group.getId(), article.getId());
+        List<ArticleGroup> articleGroups = new ArrayList<>();
+        articleGroups.add(articleGroup);
+        articleGroupRepository.saveArticleGroupList(articleGroups);
 
-    //when
-    List<Article> articles = findArticleRepository.findArticlesByGroup(group.getId(),
-        new LocationRange(new ArticleRangeRequest(5.0, 10.0, 5.0, 10.0)));
-    List<Article> articles2 = findArticleRepository.findArticlesByGroup(100L,
-        new LocationRange(new ArticleRangeRequest(5.0, 10.0, 5.0, 10.0)));
+        //when
+        List<Article> articles = findArticleRepository.findArticlesByGroup(group.getId(),
+            new LocationRange(new ArticleRangeRequest(5.0, 10.0, 5.0, 10.0)));
+        List<Article> articles2 = findArticleRepository.findArticlesByGroup(100L,
+            new LocationRange(new ArticleRangeRequest(5.0, 10.0, 5.0, 10.0)));
 
-    //then
-    assertThat(articles).hasSize(1);
-    assertThat(articles2).hasSize(0);
-  }
+        //then
+        assertThat(articles).hasSize(1);
+        assertThat(articles2).hasSize(0);
+    }
 
-  @Test
-  public void findArticle() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
+    @Test
+    public void findArticle() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
 
-    //when
-    Optional<Article> savedArticle = findArticleRepository.findById(article.getId());
+        //when
+        Optional<Article> savedArticle = findArticleRepository.findById(article.getId());
 
-    //then
-    assertThat(article.getId()).isEqualTo(savedArticle.get().getId());
-    assertThat(article.getCreate_date()).isEqualTo(savedArticle.get().getCreate_date());
-    assertThat(article.getTitle()).isEqualTo(savedArticle.get().getTitle());
-  }
+        //then
+        assertThat(article.getId()).isEqualTo(savedArticle.get().getId());
+        assertThat(article.getCreate_date()).isEqualTo(savedArticle.get().getCreate_date());
+        assertThat(article.getTitle()).isEqualTo(savedArticle.get().getTitle());
+    }
 
-  @Test
-  public void findArticleDetails(){
-    //given
-    Member member1 = buildMember();
-    memberRepository.saveMember(member1);
-    Member member2 = buildMember();
-    memberRepository.saveMember(member2);
-    Article article = buildArticle(member1.getId());
-    createArticleRepository.saveArticle(article);
-    ArticleLike articleLike1 = buildArticleLike(member1.getId(), article.getId());
-    articleLikeRepository.saveArticleLike(articleLike1);
-    ArticleLike articleLike2 = buildArticleLike(member2.getId(), article.getId());
-    articleLikeRepository.saveArticleLike(articleLike2);
+    @Test
+    public void findArticleDetails() {
+        //given
+        Member member1 = buildMember();
+        memberRepository.saveMember(member1);
+        Member member2 = buildMember();
+        memberRepository.saveMember(member2);
+        Article article = buildArticle(member1.getId());
+        createArticleRepository.saveArticle(article);
+        ArticleLike articleLike1 = buildArticleLike(member1.getId(), article.getId());
+        articleLikeRepository.saveArticleLike(articleLike1);
+        ArticleLike articleLike2 = buildArticleLike(member2.getId(), article.getId());
+        articleLikeRepository.saveArticleLike(articleLike2);
 
-    //when
-    ArticleDetailsDto details = findArticleRepository.findArticleDetails(article.getId());
+        //when
+        ArticleDetailsDto details = findArticleRepository.findArticleDetails(article.getId());
 
-    //then
-    assertThat(details.getContent()).isEqualTo(article.getContent());
-    assertThat(details.getAuthor().getNickName()).isEqualTo(member1.getNick_name());
-    assertThat(details.getTotalLikes()).isEqualTo(2L);
+        //then
+        assertThat(details.getContent()).isEqualTo(article.getContent());
+        assertThat(details.getAuthor().getNickName()).isEqualTo(member1.getNick_name());
+        assertThat(details.getTotalLikes()).isEqualTo(2L);
 
-  }
+    }
 
-  private void saveArticle(double lat, double lng, boolean publicMap, boolean privateMap) {
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    System.out.println("memberId: " + member.getId());
-    Article article = Article.builder()
-        .content("test")
-        .latitude(lat)
-        .longitude(lng)
-        .public_map(publicMap)
-        .private_map(privateMap)
-        .title("test")
-        .create_date(new Date())
-        .member_id(member.getId()).build();
-    createArticleRepository.saveArticle(article);
-  }
+    private void saveArticle(double lat, double lng, boolean publicMap, boolean privateMap) {
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        System.out.println("memberId: " + member.getId());
+        Article article = Article.builder()
+            .content("test")
+            .latitude(lat)
+            .longitude(lng)
+            .public_map(publicMap)
+            .private_map(privateMap)
+            .title("test")
+            .create_date(new Date())
+            .member_id(member.getId()).build();
+        createArticleRepository.saveArticle(article);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/articleLike/ArticleLikeRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/articleLike/ArticleLikeRepositoryTest.java
@@ -15,73 +15,73 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class ArticleLikeRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private ArticleLikeRepository articleLikeRepository;
+    @Autowired
+    private ArticleLikeRepository articleLikeRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Test
-  public void saveArticleLike() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    ArticleLike articleLike = createArticleLike(article.getId(), member.getId());
+    @Test
+    public void saveArticleLike() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        ArticleLike articleLike = createArticleLike(article.getId(), member.getId());
 
-    //when
-    articleLikeRepository.saveArticleLike(articleLike);
+        //when
+        articleLikeRepository.saveArticleLike(articleLike);
 
-    //then
-    assertThat(articleLike.getId()).isNotNull();
-  }
+        //then
+        assertThat(articleLike.getId()).isNotNull();
+    }
 
-  @Test
-  public void existsMyLike() {
-    //given
-    ArticleLike articleLike = setUpArticleLike();
-    ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleLike.getArticle_id(),
-        articleLike.getMember_id());
-    ArticleLikeDto dummyDto = new ArticleLikeDto(100L,
-        1L);
+    @Test
+    public void existsMyLike() {
+        //given
+        ArticleLike articleLike = setUpArticleLike();
+        ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleLike.getArticle_id(),
+            articleLike.getMember_id());
+        ArticleLikeDto dummyDto = new ArticleLikeDto(100L,
+            1L);
 
-    //when & then
-    assertThat(articleLikeRepository.existsMyLike(articleLikeDto)).isTrue();
-    assertThat(articleLikeRepository.existsMyLike(dummyDto)).isFalse();
-  }
+        //when & then
+        assertThat(articleLikeRepository.existsMyLike(articleLikeDto)).isTrue();
+        assertThat(articleLikeRepository.existsMyLike(dummyDto)).isFalse();
+    }
 
-  @Test
-  public void deleteArticleLike() {
-    //given
-    ArticleLike articleLike = setUpArticleLike();
-    ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleLike.getArticle_id(),
-        articleLike.getMember_id());
+    @Test
+    public void deleteArticleLike() {
+        //given
+        ArticleLike articleLike = setUpArticleLike();
+        ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleLike.getArticle_id(),
+            articleLike.getMember_id());
 
-    //when
-    int result = articleLikeRepository.deleteArticleLike(articleLikeDto);
+        //when
+        int result = articleLikeRepository.deleteArticleLike(articleLikeDto);
 
-    //then
-    assertThat(result).isEqualTo(1);
-  }
+        //then
+        assertThat(result).isEqualTo(1);
+    }
 
-  private ArticleLike createArticleLike(Long articleId, Long memberId) {
-    return ArticleLike.builder()
-        .article_id(articleId)
-        .member_id(memberId).build();
-  }
+    private ArticleLike createArticleLike(Long articleId, Long memberId) {
+        return ArticleLike.builder()
+            .article_id(articleId)
+            .member_id(memberId).build();
+    }
 
-  private ArticleLike setUpArticleLike() {
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    ArticleLike articleLike = createArticleLike(article.getId(), member.getId());
-    articleLikeRepository.saveArticleLike(articleLike);
+    private ArticleLike setUpArticleLike() {
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        ArticleLike articleLike = createArticleLike(article.getId(), member.getId());
+        articleLikeRepository.saveArticleLike(articleLike);
 
-    return articleLike;
-  }
+        return articleLike;
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/comment/CreateCommentRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/comment/CreateCommentRepositoryTest.java
@@ -14,28 +14,28 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class CreateCommentRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private CreateCommentRepository createCommentRepository;
+    @Autowired
+    private CreateCommentRepository createCommentRepository;
 
-  @Test
-  public void createComment() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    Comment comment = buildComment(member.getId(), article.getId());
+    @Test
+    public void createComment() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Comment comment = buildComment(member.getId(), article.getId());
 
-    //when
-    createCommentRepository.saveComment(comment);
+        //when
+        createCommentRepository.saveComment(comment);
 
-    //then
-    assertThat(comment.getId()).isNotNull();
-  }
+        //then
+        assertThat(comment.getId()).isNotNull();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/comment/DeleteCommentRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/comment/DeleteCommentRepositoryTest.java
@@ -20,61 +20,61 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class DeleteCommentRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private CreateCommentRepository createCommentRepository;
+    @Autowired
+    private CreateCommentRepository createCommentRepository;
 
-  @Autowired
-  private DeleteCommentRepository deleteCommentRepository;
-  @Autowired
-  private FindCommentRepository findCommentRepository;
+    @Autowired
+    private DeleteCommentRepository deleteCommentRepository;
+    @Autowired
+    private FindCommentRepository findCommentRepository;
 
-  @Test
-  public void deleteArticle() {
-    //given
-    Long memberId = 1L;
-    Long anotherId = 100L;
-    Comment comment = setup(memberId);
+    @Test
+    public void deleteArticle() {
+        //given
+        Long memberId = 1L;
+        Long anotherId = 100L;
+        Comment comment = setup(memberId);
 
-    //when & then
-    assertThat(findCommentRepository.findById(comment.getId()))
-        .isNotNull();
-    assertThat(deleteCommentRepository.deleteComment(comment.getId(), anotherId))
-        .isEqualTo(0);
-    assertThat(findCommentRepository.findById(comment.getId()))
-        .isNotNull();
-    assertThat(deleteCommentRepository.deleteComment(comment.getId(), memberId))
-        .isEqualTo(1);
-    assertThat(findCommentRepository.findById(comment.getId()))
-        .isNull();
-  }
+        //when & then
+        assertThat(findCommentRepository.findById(comment.getId()))
+            .isNotNull();
+        assertThat(deleteCommentRepository.deleteComment(comment.getId(), anotherId))
+            .isEqualTo(0);
+        assertThat(findCommentRepository.findById(comment.getId()))
+            .isNotNull();
+        assertThat(deleteCommentRepository.deleteComment(comment.getId(), memberId))
+            .isEqualTo(1);
+        assertThat(findCommentRepository.findById(comment.getId()))
+            .isNull();
+    }
 
-  private Comment setup(Long memberId) {
-    Member member = buildMember(memberId);
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    Comment comment = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment);
-    return comment;
-  }
+    private Comment setup(Long memberId) {
+        Member member = buildMember(memberId);
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Comment comment = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment);
+        return comment;
+    }
 
-  private Member buildMember(Long memberId) {
-    return Member.builder()
-        .id(memberId)
-        .nick_name("nickName")
-        .email("email")
-        .provider(AuthProvider.google)
-        .password("password")
-        .provider_id("test")
-        .image_url(null)
-        .join_date(new Date())
-        .role(Role.USER)
-        .build();
-  }
+    private Member buildMember(Long memberId) {
+        return Member.builder()
+            .id(memberId)
+            .nick_name("nickName")
+            .email("email")
+            .provider(AuthProvider.google)
+            .password("password")
+            .provider_id("test")
+            .image_url(null)
+            .join_date(new Date())
+            .role(Role.USER)
+            .build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/comment/EdidCommentRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/comment/EdidCommentRepositoryTest.java
@@ -19,58 +19,59 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class EdidCommentRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private CreateCommentRepository createCommentRepository;
+    @Autowired
+    private CreateCommentRepository createCommentRepository;
 
-  @Autowired
-  private EditCommentRepository editCommentRepository;
+    @Autowired
+    private EditCommentRepository editCommentRepository;
 
-  @Autowired
-  private FindCommentRepository findCommentRepository;
+    @Autowired
+    private FindCommentRepository findCommentRepository;
 
-  @Test
-  public void editArticle() {
-    //given
-    Long memberId = 1L;
-    Long anotherId = 100L;
-    Comment comment = setup(memberId);
-    String newContent = "수정된 내용";
+    @Test
+    public void editArticle() {
+        //given
+        Long memberId = 1L;
+        Long anotherId = 100L;
+        Comment comment = setup(memberId);
+        String newContent = "수정된 내용";
 
-    //when & then
-    assertThat(editCommentRepository.editComment(comment.getId(), anotherId, newContent))
-        .isEqualTo(0);
-    assertThat(editCommentRepository.editComment(comment.getId(), memberId, newContent))
-        .isEqualTo(1);
-    assertThat(findCommentRepository.findById(comment.getId()).getContent())
-        .isEqualTo(newContent);
-  }
+        //when & then
+        assertThat(editCommentRepository.editComment(comment.getId(), anotherId, newContent))
+            .isEqualTo(0);
+        assertThat(editCommentRepository.editComment(comment.getId(), memberId, newContent))
+            .isEqualTo(1);
+        assertThat(findCommentRepository.findById(comment.getId()).getContent())
+            .isEqualTo(newContent);
+    }
 
-  private Comment setup(Long memberId) {
-    Member member = buildMember(memberId);
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    Comment comment = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment);
-    return comment;
-  }
-  private Member buildMember(Long memberId) {
-    return Member.builder()
-        .id(memberId)
-        .nick_name("nickName")
-        .email("email")
-        .provider(AuthProvider.google)
-        .password("password")
-        .provider_id("test")
-        .image_url(null)
-        .join_date(new Date())
-        .role(Role.USER)
-        .build();
-  }
+    private Comment setup(Long memberId) {
+        Member member = buildMember(memberId);
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Comment comment = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment);
+        return comment;
+    }
+
+    private Member buildMember(Long memberId) {
+        return Member.builder()
+            .id(memberId)
+            .nick_name("nickName")
+            .email("email")
+            .provider(AuthProvider.google)
+            .password("password")
+            .provider_id("test")
+            .image_url(null)
+            .join_date(new Date())
+            .role(Role.USER)
+            .build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/comment/FindCommentRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/comment/FindCommentRepositoryTest.java
@@ -19,51 +19,51 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class FindCommentRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateCommentRepository createCommentRepository;
+    @Autowired
+    private CreateCommentRepository createCommentRepository;
 
-  @Autowired
-  private CommentLikeRepository commentLikeRepository;
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
 
-  @Autowired
-  private FindCommentRepository findCommentRepository;
+    @Autowired
+    private FindCommentRepository findCommentRepository;
 
-  @Test
-  public void findAllByArticleId() {
-    //given
-    Member member1 = buildMember();
-    memberRepository.saveMember(member1);
-    Member member2 = buildMember();
-    memberRepository.saveMember(member2);
-    Article article = buildArticle(member1.getId());
-    createArticleRepository.saveArticle(article);
-    //2개의 댓글
-    Comment comment1 = buildComment(member1.getId(), article.getId());
-    createCommentRepository.saveComment(comment1);
-    Comment comment2 = buildComment(member2.getId(), article.getId());
-    createCommentRepository.saveComment(comment2);
-    //3개의 좋아요
-    CommentLike commentLike1 = createCommentLike(comment1.getId(), member1.getId());
-    commentLikeRepository.saveCommentLike(commentLike1);
-    CommentLike commentLike2 = createCommentLike(comment1.getId(), member2.getId());
-    commentLikeRepository.saveCommentLike(commentLike2);
-    CommentLike commentLike3 = createCommentLike(comment2.getId(), member1.getId());
-    commentLikeRepository.saveCommentLike(commentLike3);
+    @Test
+    public void findAllByArticleId() {
+        //given
+        Member member1 = buildMember();
+        memberRepository.saveMember(member1);
+        Member member2 = buildMember();
+        memberRepository.saveMember(member2);
+        Article article = buildArticle(member1.getId());
+        createArticleRepository.saveArticle(article);
+        //2개의 댓글
+        Comment comment1 = buildComment(member1.getId(), article.getId());
+        createCommentRepository.saveComment(comment1);
+        Comment comment2 = buildComment(member2.getId(), article.getId());
+        createCommentRepository.saveComment(comment2);
+        //3개의 좋아요
+        CommentLike commentLike1 = createCommentLike(comment1.getId(), member1.getId());
+        commentLikeRepository.saveCommentLike(commentLike1);
+        CommentLike commentLike2 = createCommentLike(comment1.getId(), member2.getId());
+        commentLikeRepository.saveCommentLike(commentLike2);
+        CommentLike commentLike3 = createCommentLike(comment2.getId(), member1.getId());
+        commentLikeRepository.saveCommentLike(commentLike3);
 
-    //when
-    List<CommentResponse> responses = findCommentRepository.findAllByArticleId(article.getId());
+        //when
+        List<CommentResponse> responses = findCommentRepository.findAllByArticleId(article.getId());
 
-    //then
-    assertThat(responses).hasSize(2);
-  }
+        //then
+        assertThat(responses).hasSize(2);
+    }
 
-  private CommentLike createCommentLike(Long commentId, Long memberId) {
-    return CommentLike.builder().comment_id(commentId).member_id(memberId).build();
-  }
+    private CommentLike createCommentLike(Long commentId, Long memberId) {
+        return CommentLike.builder().comment_id(commentId).member_id(memberId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/commentLike/CommentLIkeRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/commentLike/CommentLIkeRepositoryTest.java
@@ -17,93 +17,93 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class CommentLIkeRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateCommentRepository createCommentRepository;
+    @Autowired
+    private CreateCommentRepository createCommentRepository;
 
-  @Autowired
-  private CommentLikeRepository commentLikeRepository;
+    @Autowired
+    private CommentLikeRepository commentLikeRepository;
 
-  @Test
-  public void saveArticleLike() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    Comment comment = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment);
-    CommentLike commentLike = createCommentLike(comment.getId(), member.getId());
-    //when
-    commentLikeRepository.saveCommentLike(commentLike);
+    @Test
+    public void saveArticleLike() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Comment comment = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment);
+        CommentLike commentLike = createCommentLike(comment.getId(), member.getId());
+        //when
+        commentLikeRepository.saveCommentLike(commentLike);
 
-    //then
-    assertThat(commentLike.getId()).isNotNull();
-  }
+        //then
+        assertThat(commentLike.getId()).isNotNull();
+    }
 
-  @Test
-  public void findHasILiked() {
-    //given
-    // 2명의 유저
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Member another = buildMember();
-    memberRepository.saveMember(another);
-    //게시글 생성
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    //4개의 댓글, 3개는 member, 1개는 another
-    Comment comment1 = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment1);
-    Comment comment2 = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment2);
-    Comment comment3 = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment3);
-    Comment comment4 = buildComment(another.getId(), article.getId());
-    createCommentRepository.saveComment(comment4);
-    //3개의 좋아요, 2개는 member 1개는 another
-    CommentLike commentLike1 = createCommentLike(comment1.getId(), member.getId());
-    commentLikeRepository.saveCommentLike(commentLike1);
-    CommentLike commentLike2 = createCommentLike(comment2.getId(), another.getId());
-    commentLikeRepository.saveCommentLike(commentLike2);
-    CommentLike commentLike4 = createCommentLike(comment4.getId(), member.getId());
-    commentLikeRepository.saveCommentLike(commentLike4);
+    @Test
+    public void findHasILiked() {
+        //given
+        // 2명의 유저
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Member another = buildMember();
+        memberRepository.saveMember(another);
+        //게시글 생성
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        //4개의 댓글, 3개는 member, 1개는 another
+        Comment comment1 = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment1);
+        Comment comment2 = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment2);
+        Comment comment3 = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment3);
+        Comment comment4 = buildComment(another.getId(), article.getId());
+        createCommentRepository.saveComment(comment4);
+        //3개의 좋아요, 2개는 member 1개는 another
+        CommentLike commentLike1 = createCommentLike(comment1.getId(), member.getId());
+        commentLikeRepository.saveCommentLike(commentLike1);
+        CommentLike commentLike2 = createCommentLike(comment2.getId(), another.getId());
+        commentLikeRepository.saveCommentLike(commentLike2);
+        CommentLike commentLike4 = createCommentLike(comment4.getId(), member.getId());
+        commentLikeRepository.saveCommentLike(commentLike4);
 
-    //when
-    List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(article.getId(),
-        member.getId());
+        //when
+        List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(article.getId(),
+            member.getId());
 
-    //then
-    assertThat(commentLikes).hasSize(2);
-  }
+        //then
+        assertThat(commentLikes).hasSize(2);
+    }
 
-  @Test
-  public void deleteCommentLike() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Article article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    Comment comment = buildComment(member.getId(), article.getId());
-    createCommentRepository.saveComment(comment);
-    CommentLike commentLike = createCommentLike(comment.getId(), member.getId());
-    commentLikeRepository.saveCommentLike(commentLike);
+    @Test
+    public void deleteCommentLike() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Comment comment = buildComment(member.getId(), article.getId());
+        createCommentRepository.saveComment(comment);
+        CommentLike commentLike = createCommentLike(comment.getId(), member.getId());
+        commentLikeRepository.saveCommentLike(commentLike);
 
-    //when
-    int result = commentLikeRepository.deleteCommentLike(comment.getId(), member.getId());
+        //when
+        int result = commentLikeRepository.deleteCommentLike(comment.getId(), member.getId());
 
-    //that
-    assertThat(result).isEqualTo(1);
-  }
+        //that
+        assertThat(result).isEqualTo(1);
+    }
 
-  private CommentLike createCommentLike(Long commentId, Long memberId) {
-    return CommentLike.builder()
-        .comment_id(commentId)
-        .member_id(memberId).build();
-  }
+    private CommentLike createCommentLike(Long commentId, Long memberId) {
+        return CommentLike.builder()
+            .comment_id(commentId)
+            .member_id(memberId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/ArticleGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/ArticleGroupRepositoryTest.java
@@ -21,68 +21,70 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class ArticleGroupRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateArticleRepository createArticleRepository;
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
 
-  @Autowired
-  private GroupRepository groupRepository;
+    @Autowired
+    private GroupRepository groupRepository;
 
-  @Autowired
-  private ArticleGroupRepository articleGroupRepository;
+    @Autowired
+    private ArticleGroupRepository articleGroupRepository;
 
-  @Autowired
-  private MemberGroupRepository memberGroupRepository;
+    @Autowired
+    private MemberGroupRepository memberGroupRepository;
 
-  Member member;
-  Article article;
-  Group group;
-  @BeforeEach
-  void setUp() {
-    member = buildMember();
-    memberRepository.saveMember(member);
-    article = buildArticle(member.getId());
-    createArticleRepository.saveArticle(article);
-    group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-  }
+    Member member;
+    Article article;
+    Group group;
 
-  @Test
-  public void saveArticleGroupList() {
-    //given
-    List<ArticleGroup> articleGroups = new ArrayList<>();
-    articleGroups.add(buildArticleGroup(group.getId(), article.getId()));
+    @BeforeEach
+    void setUp() {
+        member = buildMember();
+        memberRepository.saveMember(member);
+        article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+    }
 
-    //when
-    int result = articleGroupRepository.saveArticleGroupList(articleGroups);
+    @Test
+    public void saveArticleGroupList() {
+        //given
+        List<ArticleGroup> articleGroups = new ArrayList<>();
+        articleGroups.add(buildArticleGroup(group.getId(), article.getId()));
 
-    //then
-    assertThat(result).isEqualTo(1);
+        //when
+        int result = articleGroupRepository.saveArticleGroupList(articleGroups);
 
-  }
+        //then
+        assertThat(result).isEqualTo(1);
 
-  @Test
-  public void existsArticleInMyGroup() {
-    //given
-    List<ArticleGroup> articleGroups = new ArrayList<>();
-    articleGroups.add(buildArticleGroup(group.getId(), article.getId()));
-    articleGroupRepository.saveArticleGroupList(articleGroups);
-    MemberGroup memberGroup = MemberGroup.createMemberGroup(group);
-    memberGroupRepository.saveMemberGroup(memberGroup);
+    }
 
-    //when & then
-    assertThat(
-        articleGroupRepository.existsArticleInMyGroup(article.getId(), member.getId())).isTrue();
-    assertThat(
-        articleGroupRepository.existsArticleInMyGroup(100L, member.getId())).isFalse();
-    assertThat(
-        articleGroupRepository.existsArticleInMyGroup(article.getId(), 100L)).isFalse();
+    @Test
+    public void existsArticleInMyGroup() {
+        //given
+        List<ArticleGroup> articleGroups = new ArrayList<>();
+        articleGroups.add(buildArticleGroup(group.getId(), article.getId()));
+        articleGroupRepository.saveArticleGroupList(articleGroups);
+        MemberGroup memberGroup = MemberGroup.createMemberGroup(group);
+        memberGroupRepository.saveMemberGroup(memberGroup);
 
-  }
+        //when & then
+        assertThat(
+            articleGroupRepository.existsArticleInMyGroup(article.getId(),
+                member.getId())).isTrue();
+        assertThat(
+            articleGroupRepository.existsArticleInMyGroup(100L, member.getId())).isFalse();
+        assertThat(
+            articleGroupRepository.existsArticleInMyGroup(article.getId(), 100L)).isFalse();
 
-  private ArticleGroup buildArticleGroup(Long groupId, Long articleId) {
-    return ArticleGroup.createArticleGroup(groupId, articleId);
-  }
+    }
+
+    private ArticleGroup buildArticleGroup(Long groupId, Long articleId) {
+        return ArticleGroup.createArticleGroup(groupId, articleId);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
@@ -18,158 +18,160 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class GroupRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private GroupRepository groupRepository;
+    @Autowired
+    private GroupRepository groupRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private MemberGroupRepository memberGroupRepository;
+    @Autowired
+    private MemberGroupRepository memberGroupRepository;
 
-  @Test
-  public void saveGroup() {
-    //given
-    Group group = Group.builder().create_date(new Date()).name("test_group")
-        .invitation_code("testCode").owner_id(1L).build();
+    @Test
+    public void saveGroup() {
+        //given
+        Group group = Group.builder().create_date(new Date()).name("test_group")
+            .invitation_code("testCode").owner_id(1L).build();
 
-    //when & then
-    assertThat(group.getId()).isNull();
-    groupRepository.saveGroup(group);
+        //when & then
+        assertThat(group.getId()).isNull();
+        groupRepository.saveGroup(group);
 
-    //then
-    assertThat(group.getId()).isNotNull();
-  }
+        //then
+        assertThat(group.getId()).isNotNull();
+    }
 
-  @Test
-  public void updateInvitationCode() {
-    //given
-    Group group = Group.builder().create_date(new Date()).name("test_group").owner_id(1L).build();
+    @Test
+    public void updateInvitationCode() {
+        //given
+        Group group = Group.builder().create_date(new Date()).name("test_group").owner_id(1L)
+            .build();
 
-    //when & then
-    assertThat(group.getId()).isNull();
-    groupRepository.saveGroup(group);
-    group.addInvitationCode("testCode");
-    groupRepository.updateInvitationCode(group);
+        //when & then
+        assertThat(group.getId()).isNull();
+        groupRepository.saveGroup(group);
+        group.addInvitationCode("testCode");
+        groupRepository.updateInvitationCode(group);
 
-    //then
-    assertThat(group.getInvitation_code()).isNotNull();
-  }
+        //then
+        assertThat(group.getInvitation_code()).isNotNull();
+    }
 
-  @Test
-  public void findByInvitationCode() {
-    //given
-    String invitationCode = "testCode";
-    String anotherCode = "testOrCode";
-    Group group = Group.builder().create_date(new Date()).name("test_group")
-        .invitation_code(invitationCode).owner_id(1L).build();
-    groupRepository.saveGroup(group);
+    @Test
+    public void findByInvitationCode() {
+        //given
+        String invitationCode = "testCode";
+        String anotherCode = "testOrCode";
+        Group group = Group.builder().create_date(new Date()).name("test_group")
+            .invitation_code(invitationCode).owner_id(1L).build();
+        groupRepository.saveGroup(group);
 
-    //when
-    Optional<Group> foundGroup = groupRepository.findByInvitationCode(invitationCode);
-    Optional<Group> anotherGroup = groupRepository.findByInvitationCode(anotherCode);
-    //then
-    assertThat(foundGroup).isPresent();
-    assertThat(anotherGroup).isNotPresent();
-  }
+        //when
+        Optional<Group> foundGroup = groupRepository.findByInvitationCode(invitationCode);
+        Optional<Group> anotherGroup = groupRepository.findByInvitationCode(anotherCode);
+        //then
+        assertThat(foundGroup).isPresent();
+        assertThat(anotherGroup).isNotPresent();
+    }
 
-  @Test
-  public void deleteById() {
-    //given
-    String invitationCode = "testCode";
-    Group group = Group.builder().create_date(new Date()).name("test_group")
-        .invitation_code(invitationCode).owner_id(1L).build();
-    groupRepository.saveGroup(group);
+    @Test
+    public void deleteById() {
+        //given
+        String invitationCode = "testCode";
+        Group group = Group.builder().create_date(new Date()).name("test_group")
+            .invitation_code(invitationCode).owner_id(1L).build();
+        groupRepository.saveGroup(group);
 
-    //when & then
-    assertThat(groupRepository.findById(group.getId())).isPresent();
-    int result = groupRepository.deleteById(group.getId());
-    int dummy = groupRepository.deleteById(200L);
-    assertThat(groupRepository.findById(group.getId())).isNotPresent();
-    assertThat(result).isEqualTo(1);
-    assertThat(dummy).isEqualTo(0);
-  }
+        //when & then
+        assertThat(groupRepository.findById(group.getId())).isPresent();
+        int result = groupRepository.deleteById(group.getId());
+        int dummy = groupRepository.deleteById(200L);
+        assertThat(groupRepository.findById(group.getId())).isNotPresent();
+        assertThat(result).isEqualTo(1);
+        assertThat(dummy).isEqualTo(0);
+    }
 
-  @Test
-  public void findAllByMemberId() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group1 = buildGroup(member.getId(), "testGroup1");
-    Group group2 = buildGroup(member.getId(), "testGroup2");
-    groupRepository.saveGroup(group1);
-    groupRepository.saveGroup(group2);
-    MemberGroup memberGroup1 = MemberGroup.createMemberGroup(group1.getId(), member.getId());
-    MemberGroup memberGroup2 = MemberGroup.createMemberGroup(group2.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup1);
-    memberGroupRepository.saveMemberGroup(memberGroup2);
+    @Test
+    public void findAllByMemberId() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group1 = buildGroup(member.getId(), "testGroup1");
+        Group group2 = buildGroup(member.getId(), "testGroup2");
+        groupRepository.saveGroup(group1);
+        groupRepository.saveGroup(group2);
+        MemberGroup memberGroup1 = MemberGroup.createMemberGroup(group1.getId(), member.getId());
+        MemberGroup memberGroup2 = MemberGroup.createMemberGroup(group2.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup1);
+        memberGroupRepository.saveMemberGroup(memberGroup2);
 
-    //when
-    List<Long> groupIds = groupRepository.findAllByMemberId(member.getId());
+        //when
+        List<Long> groupIds = groupRepository.findAllByMemberId(member.getId());
 
-    //then
-    assertThat(groupIds.size()).isEqualTo(2);
-  }
+        //then
+        assertThat(groupIds.size()).isEqualTo(2);
+    }
 
-  @Test
-  public void changeGroupName() {
-    //given
-    Long memberId = 12L;
-    String newName = "하하하하하하";
-    Group group = buildGroup(memberId);
-    groupRepository.saveGroup(group);
+    @Test
+    public void changeGroupName() {
+        //given
+        Long memberId = 12L;
+        String newName = "하하하하하하";
+        Group group = buildGroup(memberId);
+        groupRepository.saveGroup(group);
 
-    //when
-    int result1 = groupRepository.changeGroupName(group.getId(), 32L, newName);
-    int result2 = groupRepository.changeGroupName(233L, memberId, newName);
-    int result3 = groupRepository.changeGroupName(group.getId(), memberId, newName);
+        //when
+        int result1 = groupRepository.changeGroupName(group.getId(), 32L, newName);
+        int result2 = groupRepository.changeGroupName(233L, memberId, newName);
+        int result3 = groupRepository.changeGroupName(group.getId(), memberId, newName);
 
-    //then
-    Group editedGroup = groupRepository.findById(group.getId()).get();
-    assertThat(result1).isEqualTo(0);
-    assertThat(result2).isEqualTo(0);
-    assertThat(result3).isEqualTo(1);
-    assertThat(editedGroup.getName()).isEqualTo(newName);
-  }
+        //then
+        Group editedGroup = groupRepository.findById(group.getId()).get();
+        assertThat(result1).isEqualTo(0);
+        assertThat(result2).isEqualTo(0);
+        assertThat(result3).isEqualTo(1);
+        assertThat(editedGroup.getName()).isEqualTo(newName);
+    }
 
-  @Test
-  public void findGroupDetails() {
-    //given
-    Member member1 = buildMember();
-    memberRepository.saveMember(member1);
-    Member member2 = buildMember();
-    memberRepository.saveMember(member2);
-    Member member3 = buildMember();
-    memberRepository.saveMember(member3);
-    Group group = buildGroup(member1.getId());
-    groupRepository.saveGroup(group);
-    MemberGroup memberGroup1 = MemberGroup.createMemberGroup(group.getId(), member1.getId());
-    MemberGroup memberGroup2 = MemberGroup.createMemberGroup(group.getId(), member2.getId());
-    MemberGroup memberGroup3 = MemberGroup.createMemberGroup(group.getId(), member3.getId());
-    memberGroup2.changeImportant();
-    memberGroupRepository.saveMemberGroup(memberGroup1);
-    memberGroupRepository.saveMemberGroup(memberGroup2);
-    memberGroupRepository.saveMemberGroup(memberGroup3);
+    @Test
+    public void findGroupDetails() {
+        //given
+        Member member1 = buildMember();
+        memberRepository.saveMember(member1);
+        Member member2 = buildMember();
+        memberRepository.saveMember(member2);
+        Member member3 = buildMember();
+        memberRepository.saveMember(member3);
+        Group group = buildGroup(member1.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup1 = MemberGroup.createMemberGroup(group.getId(), member1.getId());
+        MemberGroup memberGroup2 = MemberGroup.createMemberGroup(group.getId(), member2.getId());
+        MemberGroup memberGroup3 = MemberGroup.createMemberGroup(group.getId(), member3.getId());
+        memberGroup2.changeImportant();
+        memberGroupRepository.saveMemberGroup(memberGroup1);
+        memberGroupRepository.saveMemberGroup(memberGroup2);
+        memberGroupRepository.saveMemberGroup(memberGroup3);
 
-    //when & then
-    Optional<GroupDetailsResponse> response1 = groupRepository.findGroupDetails(2L,
-        member1.getId());
-    assertThat(response1.isPresent()).isFalse();
-    Optional<GroupDetailsResponse> response2 = groupRepository.findGroupDetails(group.getId(), 32L);
-    assertThat(response2.isPresent()).isFalse();
-    Optional<GroupDetailsResponse> response3 = groupRepository.findGroupDetails(group.getId(),
-        member1.getId());
-    assertThat(response3.get().getMemberDetails()).hasSize(3);
-    assertThat(response3.get().getImportant()).isFalse();
-    Optional<GroupDetailsResponse> response4 = groupRepository.findGroupDetails(group.getId(),
-        member2.getId());
-    assertThat(response4.get().getMemberDetails()).hasSize(3);
-    assertThat(response4.get().getImportant()).isTrue();
-    assertThat(response4.get().getId()).isEqualTo(group.getId());
-  }
+        //when & then
+        Optional<GroupDetailsResponse> response1 = groupRepository.findGroupDetails(2L,
+            member1.getId());
+        assertThat(response1.isPresent()).isFalse();
+        Optional<GroupDetailsResponse> response2 = groupRepository.findGroupDetails(group.getId(),
+            32L);
+        assertThat(response2.isPresent()).isFalse();
+        Optional<GroupDetailsResponse> response3 = groupRepository.findGroupDetails(group.getId(),
+            member1.getId());
+        assertThat(response3.get().getMemberDetails()).hasSize(3);
+        assertThat(response3.get().getImportant()).isFalse();
+        Optional<GroupDetailsResponse> response4 = groupRepository.findGroupDetails(group.getId(),
+            member2.getId());
+        assertThat(response4.get().getMemberDetails()).hasSize(3);
+        assertThat(response4.get().getImportant()).isTrue();
+        assertThat(response4.get().getId()).isEqualTo(group.getId());
+    }
 
-  private Group buildGroup(Long ownerId, String invitationCode) {
-    return Group.builder().create_date(new Date()).name("test_group")
-        .invitation_code(invitationCode).owner_id(ownerId).build();
-  }
+    private Group buildGroup(Long ownerId, String invitationCode) {
+        return Group.builder().create_date(new Date()).name("test_group")
+            .invitation_code(invitationCode).owner_id(ownerId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -168,12 +168,4 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
         //then
         assertThat(responses).hasSize(1);
     }
-
-    private MemberGroup buildMemberGroup(Long groupId, Long memberId) {
-        return MemberGroup.builder()
-            .create_date(new Date())
-            .group_id(groupId)
-            .member_id(memberId)
-            .important(true).build();
-    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -17,162 +17,163 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class MeemberGroupRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private MemberGroupRepository memberGroupRepository;
+    @Autowired
+    private MemberGroupRepository memberGroupRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private GroupRepository groupRepository;
+    @Autowired
+    private GroupRepository groupRepository;
 
-  @Test
-  public void saveMemberGroup() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-    MemberGroup memberGroup = MemberGroup.builder()
-        .create_date(new Date())
-        .group_id(group.getId())
-        .member_id(member.getId())
-        .important(true).build();
+    @Test
+    public void saveMemberGroup() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = MemberGroup.builder()
+            .create_date(new Date())
+            .group_id(group.getId())
+            .member_id(member.getId())
+            .important(true).build();
 
-    //when & then
-    assertThat(memberGroup.getId()).isNull();
-    memberGroupRepository.saveMemberGroup(memberGroup);
+        //when & then
+        assertThat(memberGroup.getId()).isNull();
+        memberGroupRepository.saveMemberGroup(memberGroup);
 
-    //then
-    assertThat(memberGroup.getId()).isNotNull();
-  }
+        //then
+        assertThat(memberGroup.getId()).isNotNull();
+    }
 
-  @Test
-  public void checkAlreadyJoined() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-    MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup);
+    @Test
+    public void checkAlreadyJoined() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
 
-    //when
-    boolean result = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
-    boolean result2 = memberGroupRepository.checkAlreadyJoined(200L, 100L);
+        //when
+        boolean result = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
+        boolean result2 = memberGroupRepository.checkAlreadyJoined(200L, 100L);
 
-    //then
-    assertThat(result).isTrue();
-    assertThat(result2).isFalse();
-  }
+        //then
+        assertThat(result).isTrue();
+        assertThat(result2).isFalse();
+    }
 
-  @Test
-  public void deleteMemberGroup() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-    MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup);
+    @Test
+    public void deleteMemberGroup() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
 
-    //when
-    boolean result1 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
-    int deleted = memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
-    boolean result2 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
-    int dummyDeleted = memberGroupRepository.deleteMemberGroup(group.getId(), 1000L);
+        //when
+        boolean result1 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
+        int deleted = memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
+        boolean result2 = memberGroupRepository.checkAlreadyJoined(group.getId(), member.getId());
+        int dummyDeleted = memberGroupRepository.deleteMemberGroup(group.getId(), 1000L);
 
-    //then
-    assertThat(result1).isEqualTo(true);
-    assertThat(deleted).isEqualTo(1);
-    assertThat(result2).isEqualTo(false);
-    assertThat(dummyDeleted).isEqualTo(0);
-  }
+        //then
+        assertThat(result1).isEqualTo(true);
+        assertThat(deleted).isEqualTo(1);
+        assertThat(result2).isEqualTo(false);
+        assertThat(dummyDeleted).isEqualTo(0);
+    }
 
-  @Test
-  public void countMemberGroup() {
-    //given
-    Member member = buildMember();
-    Member member2 = buildMember();
-    memberRepository.saveMember(member);
-    memberRepository.saveMember(member2);
-    Group group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-    MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup);
-    MemberGroup memberGroup2 = buildMemberGroup(group.getId(), member2.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup2);
+    @Test
+    public void countMemberGroup() {
+        //given
+        Member member = buildMember();
+        Member member2 = buildMember();
+        memberRepository.saveMember(member);
+        memberRepository.saveMember(member2);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
+        MemberGroup memberGroup2 = buildMemberGroup(group.getId(), member2.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup2);
 
-    //when
-    Long count = memberGroupRepository.countMemberGroup(group.getId());
-    memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
-    memberGroupRepository.deleteMemberGroup(group.getId(), member2.getId());
-    Long count2 = memberGroupRepository.countMemberGroup(group.getId());
+        //when
+        Long count = memberGroupRepository.countMemberGroup(group.getId());
+        memberGroupRepository.deleteMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.deleteMemberGroup(group.getId(), member2.getId());
+        Long count2 = memberGroupRepository.countMemberGroup(group.getId());
 
-    //then
-    assertThat(count).isEqualTo(2);
-    assertThat(count2).isEqualTo(0);
-  }
+        //then
+        assertThat(count).isEqualTo(2);
+        assertThat(count2).isEqualTo(0);
+    }
 
-  @Test
-  public void changeImportant() {
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group = buildGroup(member.getId());
-    groupRepository.saveGroup(group);
-    MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup);
+    @Test
+    public void changeImportant() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
 
-    //when & then
-    assertThat(memberGroup.isImportant()).isTrue();
-    memberGroupRepository.changeImportant(group.getId(), member.getId());
-    MemberGroup changedMemberGroup = memberGroupRepository.findById(member.getId());
-    assertThat(changedMemberGroup.isImportant()).isFalse();
-    memberGroupRepository.changeImportant(group.getId(), member.getId());
-    MemberGroup changedMemberGroup2 = memberGroupRepository.findById(member.getId());
-    assertThat(changedMemberGroup2.isImportant()).isTrue();
-  }
+        //when & then
+        assertThat(memberGroup.isImportant()).isTrue();
+        memberGroupRepository.changeImportant(group.getId(), member.getId());
+        MemberGroup changedMemberGroup = memberGroupRepository.findById(member.getId());
+        assertThat(changedMemberGroup.isImportant()).isFalse();
+        memberGroupRepository.changeImportant(group.getId(), member.getId());
+        MemberGroup changedMemberGroup2 = memberGroupRepository.findById(member.getId());
+        assertThat(changedMemberGroup2.isImportant()).isTrue();
+    }
 
-  @Test
-  public void findMyImportantGroups(){
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group1 = buildGroup(member.getId());
-    groupRepository.saveGroup(group1);
-    MemberGroup memberGroup1 = buildMemberGroup(group1.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup1);
+    @Test
+    public void findMyImportantGroups() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group1 = buildGroup(member.getId());
+        groupRepository.saveGroup(group1);
+        MemberGroup memberGroup1 = buildMemberGroup(group1.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup1);
 
-    //when
-    List<GroupSummaryResponse> responses = memberGroupRepository.findMyImportantGroups(member.getId());
+        //when
+        List<GroupSummaryResponse> responses = memberGroupRepository.findMyImportantGroups(
+            member.getId());
 
-    //then
-    assertThat(responses).hasSize(1);
-  }
+        //then
+        assertThat(responses).hasSize(1);
+    }
 
-  @Test
-  public void findMyGroups(){
-    //given
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-    Group group1 = buildGroup(member.getId());
-    groupRepository.saveGroup(group1);
-    MemberGroup memberGroup1 = buildMemberGroup(group1.getId(), member.getId());
-    memberGroupRepository.saveMemberGroup(memberGroup1);
+    @Test
+    public void findMyGroups() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group1 = buildGroup(member.getId());
+        groupRepository.saveGroup(group1);
+        MemberGroup memberGroup1 = buildMemberGroup(group1.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup1);
 
-    //when
-    List<GroupSummaryResponse> responses = memberGroupRepository.findMyGroups(member.getId());
+        //when
+        List<GroupSummaryResponse> responses = memberGroupRepository.findMyGroups(member.getId());
 
-    //then
-    assertThat(responses).hasSize(1);
-  }
+        //then
+        assertThat(responses).hasSize(1);
+    }
 
-  private MemberGroup buildMemberGroup(Long groupId, Long memberId) {
-    return MemberGroup.builder()
-        .create_date(new Date())
-        .group_id(groupId)
-        .member_id(memberId)
-        .important(true).build();
-  }
+    private MemberGroup buildMemberGroup(Long groupId, Long memberId) {
+        return MemberGroup.builder()
+            .create_date(new Date())
+            .group_id(groupId)
+            .member_id(memberId)
+            .important(true).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/member/MemberRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/member/MemberRepositoryTest.java
@@ -10,44 +10,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemberRepositoryTest extends RepositoryTest {
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  private String Email = "email";
+    private String Email = "email";
 
-  @Test
-  public void saveMember() {
-    //given
-    Member member = buildMember();
+    @Test
+    public void saveMember() {
+        //given
+        Member member = buildMember();
 
-    //when
-    memberRepository.saveMember(member);
+        //when
+        memberRepository.saveMember(member);
 
-    //then
-    assertThat(member.getId()).isNotNull();
-  }
+        //then
+        assertThat(member.getId()).isNotNull();
+    }
 
-  @Test
-  public void existsByEmail() {
-    //given
-    saveOne();
+    @Test
+    public void existsByEmail() {
+        //given
+        saveOne();
 
-    //when & then
-    assertThat(memberRepository.existsByEmail("test")).isFalse();
-    assertThat(memberRepository.existsByEmail(Email)).isTrue();
-  }
+        //when & then
+        assertThat(memberRepository.existsByEmail("test")).isFalse();
+        assertThat(memberRepository.existsByEmail(Email)).isTrue();
+    }
 
-  @Test
-  public void findByEmail() {
-    //given
-    saveOne();
+    @Test
+    public void findByEmail() {
+        //given
+        saveOne();
 
-    //when & then
-    assertThat(memberRepository.findByEmail(Email).get().getNick_name()).isEqualTo("nickName");
-  }
+        //when & then
+        assertThat(memberRepository.findByEmail(Email).get().getNick_name()).isEqualTo("nickName");
+    }
 
-  private void saveOne() {
-    Member member = buildMember();
-    memberRepository.saveMember(member);
-  }
+    private void saveOne() {
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/member/MemberRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/member/MemberRepositoryTest.java
@@ -1,7 +1,18 @@
 package foot.footprint.repository.member;
 
+import foot.footprint.domain.article.dao.CreateArticleRepository;
+import foot.footprint.domain.article.domain.Article;
+import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
+import foot.footprint.domain.articleLike.domain.ArticleLike;
+import foot.footprint.domain.comment.dao.CreateCommentRepository;
+import foot.footprint.domain.comment.domain.Comment;
+import foot.footprint.domain.group.dao.GroupRepository;
+import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.domain.group.domain.Group;
+import foot.footprint.domain.group.domain.MemberGroup;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.Member;
+import foot.footprint.domain.member.dto.MyPageResponse;
 import foot.footprint.repository.RepositoryTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +23,21 @@ public class MemberRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private CreateArticleRepository createArticleRepository;
+
+    @Autowired
+    private CreateCommentRepository createCommentRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private MemberGroupRepository memberGroupRepository;
+
+    @Autowired
+    private ArticleLikeRepository articleLikeRepository;
 
     private String Email = "email";
 
@@ -44,6 +70,35 @@ public class MemberRepositoryTest extends RepositoryTest {
 
         //when & then
         assertThat(memberRepository.findByEmail(Email).get().getNick_name()).isEqualTo("nickName");
+    }
+
+    @Test
+    public void findMyPageDetails() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Article article = buildArticle(member.getId());
+        createArticleRepository.saveArticle(article);
+        Comment comment = buildComment(member.getId(), article.getId());
+        ArticleLike articleLike = buildArticleLike(member.getId(), article.getId());
+        articleLikeRepository.saveArticleLike(articleLike);
+        createCommentRepository.saveComment(comment);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
+
+        //when
+        MyPageResponse response = memberRepository.findMyPageDetails(member.getId());
+
+        //then
+        assertThat(response.getEmail()).isEqualTo(member.getEmail());
+        assertThat(response.getMyArticles()).hasSize(1);
+        assertThat(response.getMyArticles().get(0).getTotalLikes()).isEqualTo(1);
+        assertThat(response.getMyArticles().get(0).getTotalComments()).isEqualTo(1);
+        assertThat(response.getMyArticles().get(0).getTitle()).isEqualTo(article.getTitle());
+        assertThat(response.getMyGroups()).hasSize(1);
+        assertThat(response.getMyGroups().get(0).getGroupId()).isEqualTo(group.getId());
     }
 
     private void saveOne() {

--- a/backend/footprint/src/test/java/foot/footprint/service/article/CreateArticleServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/CreateArticleServiceTest.java
@@ -29,77 +29,78 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class CreateArticleServiceTest {
 
-  @Mock
-  private CreateArticleRepository createArticleRepository;
+    @Mock
+    private CreateArticleRepository createArticleRepository;
 
-  @Mock
-  private ArticleGroupRepository articleGroupRepository;
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
 
-  @Mock
-  private GroupRepository groupRepository;
+    @Mock
+    private GroupRepository groupRepository;
 
-  @InjectMocks
-  private CreateArticleService createArticleService;
+    @InjectMocks
+    private CreateArticleService createArticleService;
 
-  @Test
-  @DisplayName("게시글 생성시")
-  public void create() {
-    //given
-    Long memberId = 1L;
-    Long groupId1 = 1L;
-    Long groupId2 = 2L;
-    List<Long> groupIdsToBeIncluded = new ArrayList<>();
-    groupIdsToBeIncluded.add(groupId1);
-    groupIdsToBeIncluded.add(groupId2);
+    @Test
+    @DisplayName("게시글 생성시")
+    public void create() {
+        //given
+        Long memberId = 1L;
+        Long groupId1 = 1L;
+        Long groupId2 = 2L;
+        List<Long> groupIdsToBeIncluded = new ArrayList<>();
+        groupIdsToBeIncluded.add(groupId1);
+        groupIdsToBeIncluded.add(groupId2);
 
-    ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
-    ArgumentCaptor<List<ArticleGroup>> captor2 = ArgumentCaptor.forClass(java.util.List.class);
-    CreateArticleRequest createArticleRequest = new CreateArticleRequest("title", "content",
-        10.0, 10.0, true, true, groupIdsToBeIncluded);
+        ArgumentCaptor<Article> captor = ArgumentCaptor.forClass(Article.class);
+        ArgumentCaptor<List<ArticleGroup>> captor2 = ArgumentCaptor.forClass(java.util.List.class);
+        CreateArticleRequest createArticleRequest = new CreateArticleRequest("title", "content",
+            10.0, 10.0, true, true, groupIdsToBeIncluded);
 
-    given(createArticleRepository.saveArticle(any()))
-        .willReturn(1L);
-    given(articleGroupRepository.saveArticleGroupList(anyList()))
-        .willReturn(0);
-    given(groupRepository.findAllByMemberId(any()))
-        .willReturn(groupIdsToBeIncluded);
-    //when
-    createArticleService.create(createArticleRequest, memberId);
+        given(createArticleRepository.saveArticle(any()))
+            .willReturn(1L);
+        given(articleGroupRepository.saveArticleGroupList(anyList()))
+            .willReturn(0);
+        given(groupRepository.findAllByMemberId(any()))
+            .willReturn(groupIdsToBeIncluded);
+        //when
+        createArticleService.create(createArticleRequest, memberId);
 
-    //then
-    verify(createArticleRepository, times(1)).saveArticle(captor.capture());
-    verify(articleGroupRepository, times(1)).saveArticleGroupList(captor2.capture());
-    Article article = captor.getValue();
-    List<ArticleGroup> articleGroups = captor2.getValue();
-    assertThat(createArticleRequest.getTitle()).isEqualTo(article.getTitle());
-    assertThat(createArticleRequest.getContent()).isEqualTo(article.getContent());
-    assertThat(createArticleRequest.getGroupIdsToBeIncluded().size()).isEqualTo(articleGroups.size());
-    assertThat(articleGroups.get(0).getArticle_id()).isEqualTo(article.getId());
+        //then
+        verify(createArticleRepository, times(1)).saveArticle(captor.capture());
+        verify(articleGroupRepository, times(1)).saveArticleGroupList(captor2.capture());
+        Article article = captor.getValue();
+        List<ArticleGroup> articleGroups = captor2.getValue();
+        assertThat(createArticleRequest.getTitle()).isEqualTo(article.getTitle());
+        assertThat(createArticleRequest.getContent()).isEqualTo(article.getContent());
+        assertThat(createArticleRequest.getGroupIdsToBeIncluded().size()).isEqualTo(
+            articleGroups.size());
+        assertThat(articleGroups.get(0).getArticle_id()).isEqualTo(article.getId());
 
-    //groupIds가 중 내 그룹이 아닌 groupId가 있을 시 예외 처리
-    //given
-    List<Long> groupIds = new ArrayList<>();
-    groupIds.add(groupId1);
-    groupIds.add(100L);
-    createArticleRequest.updateGroupIdList(groupIds);
+        //groupIds가 중 내 그룹이 아닌 groupId가 있을 시 예외 처리
+        //given
+        List<Long> groupIds = new ArrayList<>();
+        groupIds.add(groupId1);
+        groupIds.add(100L);
+        createArticleRequest.updateGroupIdList(groupIds);
 
-    //when & then
-    assertThatThrownBy(
-        () -> createArticleService.create(createArticleRequest, memberId))
-        .isInstanceOf(NotIncludedMapException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> createArticleService.create(createArticleRequest, memberId))
+            .isInstanceOf(NotIncludedMapException.class);
+    }
 
-  @Test
-  @DisplayName("게시글 생성시 = 맵 타입 에러")
-  public void create_IfNotExistsMapType() {
-    //given
-    Long memberId = 1L;
-    CreateArticleRequest createArticleRequest = new CreateArticleRequest("title", "content",
-        10.0, 10.0, false, false, new ArrayList<>());
+    @Test
+    @DisplayName("게시글 생성시 = 맵 타입 에러")
+    public void create_IfNotExistsMapType() {
+        //given
+        Long memberId = 1L;
+        CreateArticleRequest createArticleRequest = new CreateArticleRequest("title", "content",
+            10.0, 10.0, false, false, new ArrayList<>());
 
-    //when & then
-    assertThatThrownBy(
-        () -> createArticleService.create(createArticleRequest, memberId))
-        .isInstanceOf(NotIncludedMapException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> createArticleService.create(createArticleRequest, memberId))
+            .isInstanceOf(NotIncludedMapException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/article/DeleteArticleServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/DeleteArticleServiceTest.java
@@ -16,21 +16,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class DeleteArticleServiceTest {
 
-  @Mock
-  private DeleteArticleRepository deleteArticleRepository;
+    @Mock
+    private DeleteArticleRepository deleteArticleRepository;
 
-  @InjectMocks
-  private DeleteArticleService deleteArticleService;
+    @InjectMocks
+    private DeleteArticleService deleteArticleService;
 
-  @Test
-  public void edit() {
-    //given
-    given(deleteArticleRepository.deleteById(any(), any()))
-        .willReturn(0);
+    @Test
+    public void edit() {
+        //given
+        given(deleteArticleRepository.deleteById(any(), any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> deleteArticleService.delete(any(), any()))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> deleteArticleService.delete(any(), any()))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/article/EditArticleServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/EditArticleServiceTest.java
@@ -16,21 +16,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class EditArticleServiceTest {
 
-  @Mock
-  private EditArticleRepository editArticleRepository;
+    @Mock
+    private EditArticleRepository editArticleRepository;
 
-  @InjectMocks
-  private EditArticleService editArticleService;
+    @InjectMocks
+    private EditArticleService editArticleService;
 
-  @Test
-  public void edit(){
-    //given
-    given(editArticleRepository.editArticle(any(), any(), any()))
-        .willReturn(0);
+    @Test
+    public void edit() {
+        //given
+        given(editArticleRepository.editArticle(any(), any(), any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> editArticleService.edit(any(), any(), any()))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> editArticleService.edit(any(), any(), any()))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
@@ -29,88 +29,89 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class FindArticleDetailsServiceTest {
 
-  @Mock
-  private FindArticleRepository findArticleRepository;
+    @Mock
+    private FindArticleRepository findArticleRepository;
 
-  @Mock
-  private ArticleLikeRepository articleLikeRepository;
+    @Mock
+    private ArticleLikeRepository articleLikeRepository;
 
-  @Mock
-  private FindCommentRepository findCommentRepository;
+    @Mock
+    private FindCommentRepository findCommentRepository;
 
-  @Mock
-  private CommentLikeRepository commentLikeRepository;
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
 
 
-  @InjectMocks
-  private FindArticleDetailsService findArticleDetailsService;
+    @InjectMocks
+    private FindArticleDetailsService findArticleDetailsService;
 
-  @BeforeEach
-  void setUp() {
-    Long memberId = 4L;
-    Long articleId = 10L;
-    //게시글 리턴
-    Article article = buildArticle(memberId, true, true);
-    given(findArticleRepository.findById(any())).willReturn(Optional.ofNullable(article));
-    //게시글 dto 리턴
-    ArticleDetailsDto details = new ArticleDetailsDto(articleId, "title", "content", 1.0, 1.0,
-        memberId, "nickName", "image", new Date(), 0L);
-    given(findArticleRepository.findArticleDetails(any())).willReturn(details);
-    //댓글 리스트 리턴
-    CommentResponse response = new CommentResponse(1L, "test", memberId, "nickName", "image",
-        new Date(), 0L);
-    List<CommentResponse> responses = new ArrayList<>();
-    responses.add(response);
-    given(findCommentRepository.findAllByArticleId(any())).willReturn(responses);
-    //게시글 좋아요 검증 리턴
-    given(articleLikeRepository.existsMyLike(any()))
-        .willReturn(true);
-    //댓글 좋아요 리스트 리턴
-    List<Long> commentLikes = new ArrayList<>();
-    commentLikes.add(1L);
-    given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
-        new ArrayList<>(commentLikes));
-  }
+    @BeforeEach
+    void setUp() {
+        Long memberId = 4L;
+        Long articleId = 10L;
+        //게시글 리턴
+        Article article = buildArticle(memberId, true, true);
+        given(findArticleRepository.findById(any())).willReturn(Optional.ofNullable(article));
+        //게시글 dto 리턴
+        ArticleDetailsDto details = new ArticleDetailsDto(articleId, "title", "content", 1.0, 1.0,
+            memberId, "nickName", "image", new Date(), 0L);
+        given(findArticleRepository.findArticleDetails(any())).willReturn(details);
+        //댓글 리스트 리턴
+        CommentResponse response = new CommentResponse(1L, "test", memberId, "nickName", "image",
+            new Date(), 0L);
+        List<CommentResponse> responses = new ArrayList<>();
+        responses.add(response);
+        given(findCommentRepository.findAllByArticleId(any())).willReturn(responses);
+        //게시글 좋아요 검증 리턴
+        given(articleLikeRepository.existsMyLike(any()))
+            .willReturn(true);
+        //댓글 좋아요 리스트 리턴
+        List<Long> commentLikes = new ArrayList<>();
+        commentLikes.add(1L);
+        given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
+            new ArrayList<>(commentLikes));
+    }
 
-  @Test
-  @DisplayName("게시글 조회 - 전체공개시")
-  public void findDetails() {
-    //given
-    Long memberId = 4L;
-    String email = "email@test.com";
-    Long articleId = 10L;
-    CustomUserDetails userDetails = new CustomUserDetails(memberId, email, null);
+    @Test
+    @DisplayName("게시글 조회 - 전체공개시")
+    public void findDetails() {
+        //given
+        Long memberId = 4L;
+        String email = "email@test.com";
+        Long articleId = 10L;
+        CustomUserDetails userDetails = new CustomUserDetails(memberId, email, null);
 
-    //when
-    ArticlePageResponse response = findArticleDetailsService.findDetails(articleId, userDetails);
+        //when
+        ArticlePageResponse response = findArticleDetailsService.findDetails(articleId,
+            userDetails);
 
-    //then
-    assertThat(response.getArticleDetails().getId()).isEqualTo(articleId);
-    assertThat(response.getComments().size()).isEqualTo(1);
-    assertThat(response.getCommentLikes().get(0)).isEqualTo(1L);
-    assertThat(response.isArticleLike()).isTrue();
-    assertThat(response.getMyMemberId()).isEqualTo(memberId);
+        //then
+        assertThat(response.getArticleDetails().getId()).isEqualTo(articleId);
+        assertThat(response.getComments().size()).isEqualTo(1);
+        assertThat(response.getCommentLikes().get(0)).isEqualTo(1L);
+        assertThat(response.isArticleLike()).isTrue();
+        assertThat(response.getMyMemberId()).isEqualTo(memberId);
 
-    //when 유저 정보가 null(로그인하지 않는 상태)
-    ArticlePageResponse response2 = findArticleDetailsService.findDetails(articleId, null);
+        //when 유저 정보가 null(로그인하지 않는 상태)
+        ArticlePageResponse response2 = findArticleDetailsService.findDetails(articleId, null);
 
-    //then
-    assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);
-    assertThat(response2.getComments().size()).isEqualTo(1);
-    assertThat(response2.getCommentLikes()).isNull();
-    assertThat(response2.isArticleLike()).isFalse();
-    assertThat(response2.getMyMemberId()).isNull();
-  }
+        //then
+        assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);
+        assertThat(response2.getComments().size()).isEqualTo(1);
+        assertThat(response2.getCommentLikes()).isNull();
+        assertThat(response2.isArticleLike()).isFalse();
+        assertThat(response2.getMyMemberId()).isNull();
+    }
 
-  private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
-    return Article.builder()
-        .content("test")
-        .latitude(10.0)
-        .longitude(10.0)
-        .public_map(publicMap)
-        .private_map(privateMap)
-        .title("test")
-        .create_date(new Date())
-        .member_id(memberId).build();
-  }
+    private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
+        return Article.builder()
+            .content("test")
+            .latitude(10.0)
+            .longitude(10.0)
+            .public_map(publicMap)
+            .private_map(privateMap)
+            .title("test")
+            .create_date(new Date())
+            .member_id(memberId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleServiceTest.java
@@ -29,74 +29,76 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 public class FindArticleServiceTest {
 
-  @Mock
-  private FindArticleRepository findArticleRepository;
+    @Mock
+    private FindArticleRepository findArticleRepository;
 
-  @Mock
-  private MemberGroupRepository memberGroupRepository;
+    @Mock
+    private MemberGroupRepository memberGroupRepository;
 
-  @Spy
-  @InjectMocks
-  private FindArticleService findArticleService;
+    @Spy
+    @InjectMocks
+    private FindArticleService findArticleService;
 
-  @Test
-  @DisplayName("전체지도 내 게시글 찾기 테스트")
-  public void findPublicMapArticlesTest() {
-    //given
-    List<Article> articles = createArticleList(createArticle());
-    Long userId = null;
-    LocationRange locationRange = new LocationRange(
-        new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
-    given(findArticleRepository.findArticles(userId, locationRange)).willReturn(articles);
+    @Test
+    @DisplayName("전체지도 내 게시글 찾기 테스트")
+    public void findPublicMapArticlesTest() {
+        //given
+        List<Article> articles = createArticleList(createArticle());
+        Long userId = null;
+        LocationRange locationRange = new LocationRange(
+            new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
+        given(findArticleRepository.findArticles(userId, locationRange)).willReturn(articles);
 
-    //when
-    List<ArticleMapResponse> responses = findArticleService.findPublicMapArticles(locationRange);
+        //when
+        List<ArticleMapResponse> responses = findArticleService.findPublicMapArticles(
+            locationRange);
 
-    //then
-    verify(findArticleRepository, times(1)).findArticles(userId, locationRange);
-    verify(findArticleService, times(1)).findPublicMapArticles(locationRange);
-    assertThat(responses).hasSize(1);
-  }
+        //then
+        verify(findArticleRepository, times(1)).findArticles(userId, locationRange);
+        verify(findArticleService, times(1)).findPublicMapArticles(locationRange);
+        assertThat(responses).hasSize(1);
+    }
 
-  @Test
-  @DisplayName("그룹지도")
-  public void groupedMapArticlesTest() {
-    //given
-    List<Article> articles = createArticleList(createArticle());
-    LocationRange locationRange = new LocationRange(
-        new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
-    given(memberGroupRepository.checkAlreadyJoined(any(), any())).willReturn(true);
-    given(findArticleRepository.findArticlesByGroup(1L, locationRange)).willReturn(articles);
+    @Test
+    @DisplayName("그룹지도")
+    public void groupedMapArticlesTest() {
+        //given
+        List<Article> articles = createArticleList(createArticle());
+        LocationRange locationRange = new LocationRange(
+            new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
+        given(memberGroupRepository.checkAlreadyJoined(any(), any())).willReturn(true);
+        given(findArticleRepository.findArticlesByGroup(1L, locationRange)).willReturn(articles);
 
-    //when
-    List<ArticleMapResponse> result = findArticleService.findGroupedArticles(1L, 1L, locationRange);
+        //when
+        List<ArticleMapResponse> result = findArticleService.findGroupedArticles(1L, 1L,
+            locationRange);
 
-    //then
-    assertThat(result.size()).isEqualTo(1);
-  }
+        //then
+        assertThat(result.size()).isEqualTo(1);
+    }
 
-  @Test
-  @DisplayName("그룹지도 - 그룹에 가입된 회원이 아닐 시")
-  public void groupedMapArticlesTest_IfNotJoined() {
-    //given
-    LocationRange locationRange = new LocationRange(
-        new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
-    given(memberGroupRepository.checkAlreadyJoined(any(), any())).willReturn(false);
+    @Test
+    @DisplayName("그룹지도 - 그룹에 가입된 회원이 아닐 시")
+    public void groupedMapArticlesTest_IfNotJoined() {
+        //given
+        LocationRange locationRange = new LocationRange(
+            new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
+        given(memberGroupRepository.checkAlreadyJoined(any(), any())).willReturn(false);
 
-    //when & then
-    assertThatThrownBy(
-        () -> findArticleService.findGroupedArticles(1L, 1L, locationRange)).isInstanceOf(
-        NotExistsException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> findArticleService.findGroupedArticles(1L, 1L, locationRange)).isInstanceOf(
+            NotExistsException.class);
+    }
 
-  private Article createArticle() {
-    return Article.builder().id(1L).content("ddddd").latitude(10.1).longitude(10.1)
-        .private_map(true).public_map(true).title("히히히히").member_id(1L).build();
-  }
+    private Article createArticle() {
+        return Article.builder().id(1L).content("ddddd").latitude(10.1).longitude(10.1)
+            .private_map(true).public_map(true).title("히히히히").member_id(1L).build();
+    }
 
-  private List<Article> createArticleList(Article article) {
-    List<Article> articles = new ArrayList<>();
-    articles.add(article);
-    return articles;
-  }
+    private List<Article> createArticleList(Article article) {
+        List<Article> articles = new ArrayList<>();
+        articles.add(article);
+        return articles;
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/articleLike/ArticleLikeServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/articleLike/ArticleLikeServiceTest.java
@@ -28,105 +28,105 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ArticleLikeServiceTest {
 
-  @Spy
-  private ArticleLikeRepository articleLikeRepository;
+    @Spy
+    private ArticleLikeRepository articleLikeRepository;
 
-  @Mock
-  private FindArticleRepository findArticleRepository;
+    @Mock
+    private FindArticleRepository findArticleRepository;
 
-  @Mock
-  private ArticleGroupRepository articleGroupRepository;
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
 
-  @Spy
-  @InjectMocks
-  private ArticleLikeService articleLikeService;
+    @Spy
+    @InjectMocks
+    private ArticleLikeService articleLikeService;
 
-  @Test
-  @DisplayName("전체 확인 가능 게시글 좋아요 변화")
-  public void changeArticleLike_IfPublicArticle() {
-    //given
-    Long articleId = 1L;
-    Long memberId = 1L;
-    Article article = buildArticle(memberId, true, true);
-    ArticleLikeDto likedArticle = new ArticleLikeDto(articleId, memberId, true);
-    ArticleLikeDto notLikedArticle = new ArticleLikeDto(articleId, memberId, false);
-    given(articleLikeRepository.deleteArticleLike(any()))
-        .willReturn(1);
-    given(findArticleRepository.findById(any()))
-        .willReturn(Optional.ofNullable(article));
+    @Test
+    @DisplayName("전체 확인 가능 게시글 좋아요 변화")
+    public void changeArticleLike_IfPublicArticle() {
+        //given
+        Long articleId = 1L;
+        Long memberId = 1L;
+        Article article = buildArticle(memberId, true, true);
+        ArticleLikeDto likedArticle = new ArticleLikeDto(articleId, memberId, true);
+        ArticleLikeDto notLikedArticle = new ArticleLikeDto(articleId, memberId, false);
+        given(articleLikeRepository.deleteArticleLike(any()))
+            .willReturn(1);
+        given(findArticleRepository.findById(any()))
+            .willReturn(Optional.ofNullable(article));
 
-    //when
-    articleLikeService.changeArticleLike(likedArticle);
+        //when
+        articleLikeService.changeArticleLike(likedArticle);
 
-    //then
-    verify(articleLikeRepository, times(1)).deleteArticleLike(any());
-    verify(articleLikeRepository, times(0)).saveArticleLike(any());
+        //then
+        verify(articleLikeRepository, times(1)).deleteArticleLike(any());
+        verify(articleLikeRepository, times(0)).saveArticleLike(any());
 
-    //when
-    articleLikeService.changeArticleLike(notLikedArticle);
+        //when
+        articleLikeService.changeArticleLike(notLikedArticle);
 
-    //then
-    verify(articleLikeRepository, times(1)).saveArticleLike(any());
+        //then
+        verify(articleLikeRepository, times(1)).saveArticleLike(any());
 
-    //given
-    given(articleLikeRepository.deleteArticleLike(any()))
-        .willReturn(0);
+        //given
+        given(articleLikeRepository.deleteArticleLike(any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> articleLikeService.changeArticleLike(likedArticle))
-        .isInstanceOf(NotExistsException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> articleLikeService.changeArticleLike(likedArticle))
+            .isInstanceOf(NotExistsException.class);
+    }
 
-  @Test
-  @DisplayName("개인 확인 가능 게시글 좋아요 변화")
-  public void changeArticleLike_IfPrivateArticle() {
-    //changeLike에 대한 테스트는 publicArticle에서 진행하였으므로 validate만 진행
-    //given
-    Long articleId = 1L;
-    Long memberId = 1L;
-    Long anotherMemberId = 2L;
-    Article article = buildArticle(memberId, false, true);
-    ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleId, anotherMemberId);
-    given(findArticleRepository.findById(any()))
-        .willReturn(Optional.ofNullable(article));
+    @Test
+    @DisplayName("개인 확인 가능 게시글 좋아요 변화")
+    public void changeArticleLike_IfPrivateArticle() {
+        //changeLike에 대한 테스트는 publicArticle에서 진행하였으므로 validate만 진행
+        //given
+        Long articleId = 1L;
+        Long memberId = 1L;
+        Long anotherMemberId = 2L;
+        Article article = buildArticle(memberId, false, true);
+        ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleId, anotherMemberId);
+        given(findArticleRepository.findById(any()))
+            .willReturn(Optional.ofNullable(article));
 
-    //when & then
-    assertThatThrownBy(
-        () -> articleLikeService.changeArticleLike(articleLikeDto))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> articleLikeService.changeArticleLike(articleLikeDto))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 
-  @Test
-  @DisplayName("그룹 확인 가능 게시글 좋아요 변화")
-  public void changeArticleLike_IfGroupedArticle() {
-    //changeLike에 대한 테스트는 publicArticle에서 진행하였으므로 validate만 진행
-    //given
-    Long articleId = 1L;
-    Long memberId = 1L;
-    Long anotherMemberId = 2L;
-    Article article = buildArticle(memberId, false, false);
-    ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleId, anotherMemberId);
-    given(findArticleRepository.findById(any()))
-        .willReturn(Optional.ofNullable(article));
-    given(articleGroupRepository.existsArticleInMyGroup(any(), any()))
-        .willReturn(false);
+    @Test
+    @DisplayName("그룹 확인 가능 게시글 좋아요 변화")
+    public void changeArticleLike_IfGroupedArticle() {
+        //changeLike에 대한 테스트는 publicArticle에서 진행하였으므로 validate만 진행
+        //given
+        Long articleId = 1L;
+        Long memberId = 1L;
+        Long anotherMemberId = 2L;
+        Article article = buildArticle(memberId, false, false);
+        ArticleLikeDto articleLikeDto = new ArticleLikeDto(articleId, anotherMemberId);
+        given(findArticleRepository.findById(any()))
+            .willReturn(Optional.ofNullable(article));
+        given(articleGroupRepository.existsArticleInMyGroup(any(), any()))
+            .willReturn(false);
 
-    //when & then
-    assertThatThrownBy(
-        () -> articleLikeService.changeArticleLike(articleLikeDto))
-        .isInstanceOf(NotAuthorizedOrExistException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> articleLikeService.changeArticleLike(articleLikeDto))
+            .isInstanceOf(NotAuthorizedOrExistException.class);
+    }
 
-  private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
-    return Article.builder()
-        .content("test")
-        .latitude(10.0)
-        .longitude(10.0)
-        .public_map(publicMap)
-        .private_map(privateMap)
-        .title("test")
-        .create_date(new Date())
-        .member_id(memberId).build();
-  }
+    private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
+        return Article.builder()
+            .content("test")
+            .latitude(10.0)
+            .longitude(10.0)
+            .public_map(publicMap)
+            .private_map(privateMap)
+            .title("test")
+            .create_date(new Date())
+            .member_id(memberId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/comment/CreateCommentServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/comment/CreateCommentServiceTest.java
@@ -29,95 +29,96 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class CreateCommentServiceTest {
 
-  @Mock
-  private MemberRepository memberRepository;
+    @Mock
+    private MemberRepository memberRepository;
 
-  @Mock
-  private FindArticleRepository findArticleRepository;
+    @Mock
+    private FindArticleRepository findArticleRepository;
 
-  @Mock
-  private ArticleGroupRepository articleGroupRepository;
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
 
-  @Mock
-  private CreateCommentRepository createCommentRepository;
+    @Mock
+    private CreateCommentRepository createCommentRepository;
 
-  @InjectMocks
-  private CreateCommentService createCommentService;
+    @InjectMocks
+    private CreateCommentService createCommentService;
 
-  @Test
-  @DisplayName("댓글 작성 테스트 -- 전체 지도")
-  public void create_IfPublicMap() {
-    //given
-    Long memberId = 10L;
-    String content = "이것은 테스트 입니다.";
-    given(memberRepository.findById(any()))
-        .willReturn(Optional.ofNullable(createMember(memberId)));
-    given(findArticleRepository.findById(any())).willReturn(
-        Optional.ofNullable(createArticle(memberId, false, true)));
+    @Test
+    @DisplayName("댓글 작성 테스트 -- 전체 지도")
+    public void create_IfPublicMap() {
+        //given
+        Long memberId = 10L;
+        String content = "이것은 테스트 입니다.";
+        given(memberRepository.findById(any()))
+            .willReturn(Optional.ofNullable(createMember(memberId)));
+        given(findArticleRepository.findById(any())).willReturn(
+            Optional.ofNullable(createArticle(memberId, false, true)));
 
-    //when
-    CommentResponse response = createCommentService.create(1L, content, memberId);
+        //when
+        CommentResponse response = createCommentService.create(1L, content, memberId);
 
-    //then
-    assertThat(response.getAuthor().getId()).isEqualTo(memberId);
-    assertThat(response.getContent()).isEqualTo(content);
-  }
+        //then
+        assertThat(response.getAuthor().getId()).isEqualTo(memberId);
+        assertThat(response.getContent()).isEqualTo(content);
+    }
 
-  @Test
-  @DisplayName("댓글 작성 테스트 -- 전체 지도")
-  public void create_IfPrivateMap() {
-    //given
-    Long memberId = 10L;
-    Long anotherId = 20L;
-    String content = "이것은 테스트 입니다.";
-    given(memberRepository.findById(any()))
-        .willReturn(Optional.ofNullable(createMember(memberId)));
-    given(findArticleRepository.findById(any())).willReturn(
-        Optional.ofNullable(createArticle(memberId, true, false)));
+    @Test
+    @DisplayName("댓글 작성 테스트 -- 전체 지도")
+    public void create_IfPrivateMap() {
+        //given
+        Long memberId = 10L;
+        Long anotherId = 20L;
+        String content = "이것은 테스트 입니다.";
+        given(memberRepository.findById(any()))
+            .willReturn(Optional.ofNullable(createMember(memberId)));
+        given(findArticleRepository.findById(any())).willReturn(
+            Optional.ofNullable(createArticle(memberId, true, false)));
 
-    //when
-    CommentResponse response = createCommentService.create(1L, content, memberId);
+        //when
+        CommentResponse response = createCommentService.create(1L, content, memberId);
 
-    //then
-    assertThat(response.getAuthor().getId()).isEqualTo(memberId);
-    assertThat(response.getContent()).isEqualTo(content);
+        //then
+        assertThat(response.getAuthor().getId()).isEqualTo(memberId);
+        assertThat(response.getContent()).isEqualTo(content);
 
-    //given 개인 권한이 없을 시 예외 처리
-    given(memberRepository.findById(any()))
-        .willReturn(Optional.ofNullable(createMember(anotherId)));
+        //given 개인 권한이 없을 시 예외 처리
+        given(memberRepository.findById(any()))
+            .willReturn(Optional.ofNullable(createMember(anotherId)));
 
-    //when & then
-    assertThatThrownBy(
-        () -> createCommentService.create(1L, content, anotherId))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> createCommentService.create(1L, content, anotherId))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 
-  @Test
-  @DisplayName("댓글 작성 테스트 -- 그룹지도 예외처리")
-  public void create_IfGroupedMap() {
-    //given
-    Long memberId = 10L;
-    String content = "이것은 테스트 입니다.";
-    given(memberRepository.findById(any()))
-        .willReturn(Optional.ofNullable(createMember(memberId)));
-    given(findArticleRepository.findById(any())).willReturn(
-        Optional.ofNullable(createArticle(memberId, false, false)));
-    given(articleGroupRepository.existsArticleInMyGroup(any(), any())).willReturn(false);
+    @Test
+    @DisplayName("댓글 작성 테스트 -- 그룹지도 예외처리")
+    public void create_IfGroupedMap() {
+        //given
+        Long memberId = 10L;
+        String content = "이것은 테스트 입니다.";
+        given(memberRepository.findById(any()))
+            .willReturn(Optional.ofNullable(createMember(memberId)));
+        given(findArticleRepository.findById(any())).willReturn(
+            Optional.ofNullable(createArticle(memberId, false, false)));
+        given(articleGroupRepository.existsArticleInMyGroup(any(), any())).willReturn(false);
 
-    //when & then
-    assertThatThrownBy(
-        () -> createCommentService.create(1L, content, memberId))
-        .isInstanceOf(NotAuthorizedOrExistException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> createCommentService.create(1L, content, memberId))
+            .isInstanceOf(NotAuthorizedOrExistException.class);
+    }
 
-  private Article createArticle(Long memberId, boolean privateMap, boolean publicMap) {
-    return Article.builder().id(1L).content("ddddd").latitude(10.1).longitude(10.1)
-        .private_map(privateMap).public_map(publicMap).title("히히히히").member_id(memberId).build();
-  }
+    private Article createArticle(Long memberId, boolean privateMap, boolean publicMap) {
+        return Article.builder().id(1L).content("ddddd").latitude(10.1).longitude(10.1)
+            .private_map(privateMap).public_map(publicMap).title("히히히히").member_id(memberId)
+            .build();
+    }
 
-  private Member createMember(Long memberId) {
-    return Member.builder().id(memberId).email("test").image_url("테스트입니다").provider_id("test")
-        .provider(AuthProvider.google).nick_name("tset").role(Role.USER).join_date(new Date())
-        .password("password").build();
-  }
+    private Member createMember(Long memberId) {
+        return Member.builder().id(memberId).email("test").image_url("테스트입니다").provider_id("test")
+            .provider(AuthProvider.google).nick_name("tset").role(Role.USER).join_date(new Date())
+            .password("password").build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/comment/DeleteCommentServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/comment/DeleteCommentServiceTest.java
@@ -16,21 +16,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class DeleteCommentServiceTest {
 
-  @Mock
-  private DeleteCommentRepository deleteCommentRepository;
+    @Mock
+    private DeleteCommentRepository deleteCommentRepository;
 
-  @InjectMocks
-  private DeleteCommentService deleteCommentService;
+    @InjectMocks
+    private DeleteCommentService deleteCommentService;
 
-  @Test
-  void edit() {
-    //given
-    given(deleteCommentRepository.deleteComment(any(), any()))
-        .willReturn(0);
+    @Test
+    void edit() {
+        //given
+        given(deleteCommentRepository.deleteComment(any(), any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> deleteCommentService.delete(any(), any()))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> deleteCommentService.delete(any(), any()))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/comment/EditCommentServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/comment/EditCommentServiceTest.java
@@ -16,21 +16,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class EditCommentServiceTest {
 
-  @Mock
-  private EditCommentRepository editCommentRepository;
+    @Mock
+    private EditCommentRepository editCommentRepository;
 
-  @InjectMocks
-  private EditCommentService editCommentService;
+    @InjectMocks
+    private EditCommentService editCommentService;
 
-  @Test
-  void edit(){
-    //given
-    given(editCommentRepository.editComment(any(), any(), any()))
-        .willReturn(0);
+    @Test
+    void edit() {
+        //given
+        given(editCommentRepository.editComment(any(), any(), any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> editCommentService.edit(any(), any(), any()))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> editCommentService.edit(any(), any(), any()))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/commentLike/CommentLikeServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/commentLike/CommentLikeServiceTest.java
@@ -26,83 +26,84 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class CommentLikeServiceTest {
 
-  @Mock
-  private FindArticleRepository findArticleRepository;
+    @Mock
+    private FindArticleRepository findArticleRepository;
 
-  @Spy
-  private CommentLikeRepository commentLikeRepository;
+    @Spy
+    private CommentLikeRepository commentLikeRepository;
 
-  @Mock
-  private ArticleGroupRepository articleGroupRepository;
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
 
-  @InjectMocks
-  private CommentLikeService commentLikeService;
+    @InjectMocks
+    private CommentLikeService commentLikeService;
 
-  @Test
-  @DisplayName("댓글 좋아요 변화 - 전체지도 시")
-  public void changeMyLike() {
-    //given 좋아요를 안했을 시
-    Long memberId = 1L;
-    given(findArticleRepository.findById(any())).willReturn(
-        Optional.ofNullable(createArticle(memberId, false, true)));
-    given(commentLikeRepository.saveCommentLike(any())).willReturn(1);
+    @Test
+    @DisplayName("댓글 좋아요 변화 - 전체지도 시")
+    public void changeMyLike() {
+        //given 좋아요를 안했을 시
+        Long memberId = 1L;
+        given(findArticleRepository.findById(any())).willReturn(
+            Optional.ofNullable(createArticle(memberId, false, true)));
+        given(commentLikeRepository.saveCommentLike(any())).willReturn(1);
 
-    //when
-    commentLikeService.changeMyLike(1L, 1L, false, 1L);
+        //when
+        commentLikeService.changeMyLike(1L, 1L, false, 1L);
 
-    //then
-    verify(commentLikeRepository, times(1)).saveCommentLike(any());
-    verify(commentLikeRepository, times(0)).deleteCommentLike(any(), any());
+        //then
+        verify(commentLikeRepository, times(1)).saveCommentLike(any());
+        verify(commentLikeRepository, times(0)).deleteCommentLike(any(), any());
 
-    //given 이미 좋아요 했을 시
-    given(commentLikeRepository.deleteCommentLike(any(), any())).willReturn(1);
+        //given 이미 좋아요 했을 시
+        given(commentLikeRepository.deleteCommentLike(any(), any())).willReturn(1);
 
-    //when
-    commentLikeService.changeMyLike(1L, 1L, true, 1L);
+        //when
+        commentLikeService.changeMyLike(1L, 1L, true, 1L);
 
-    //then
-    verify(commentLikeRepository, times(1)).deleteCommentLike(any(), any());
+        //then
+        verify(commentLikeRepository, times(1)).deleteCommentLike(any(), any());
 
-    //given 이미 좋아요 했을 시, 예외 발생시
-    given(commentLikeRepository.deleteCommentLike(any(), any())).willReturn(0);
+        //given 이미 좋아요 했을 시, 예외 발생시
+        given(commentLikeRepository.deleteCommentLike(any(), any())).willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> commentLikeService.changeMyLike(1L, 1L, true, 1L))
-        .isInstanceOf(NotExistsException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> commentLikeService.changeMyLike(1L, 1L, true, 1L))
+            .isInstanceOf(NotExistsException.class);
+    }
 
-  @Test
-  @DisplayName("댓글 좋아요 변화 - 개인지도 시")
-  public void changeMyLike_IfPrivateArticle() {
-    //given
-    Long memberId = 1L;
-    given(findArticleRepository.findById(any())).willReturn(
-        Optional.ofNullable(createArticle(memberId, true, false)));
+    @Test
+    @DisplayName("댓글 좋아요 변화 - 개인지도 시")
+    public void changeMyLike_IfPrivateArticle() {
+        //given
+        Long memberId = 1L;
+        given(findArticleRepository.findById(any())).willReturn(
+            Optional.ofNullable(createArticle(memberId, true, false)));
 
-    //when & then
-    assertThatThrownBy(
-        () -> commentLikeService.changeMyLike(1L, 1L, true, 2L))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> commentLikeService.changeMyLike(1L, 1L, true, 2L))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 
-  @Test
-  @DisplayName("댓글 좋아요 변화 - 그룹지도 시")
-  public void changeMyLike_IfGroupedArticle() {
-    //given
-    Long memberId = 1L;
-    given(findArticleRepository.findById(any())).willReturn(
-        Optional.ofNullable(createArticle(memberId, false, false)));
-    given(articleGroupRepository.existsArticleInMyGroup(any(), any())).willReturn(false);
+    @Test
+    @DisplayName("댓글 좋아요 변화 - 그룹지도 시")
+    public void changeMyLike_IfGroupedArticle() {
+        //given
+        Long memberId = 1L;
+        given(findArticleRepository.findById(any())).willReturn(
+            Optional.ofNullable(createArticle(memberId, false, false)));
+        given(articleGroupRepository.existsArticleInMyGroup(any(), any())).willReturn(false);
 
-    //when & then
-    assertThatThrownBy(
-        () -> commentLikeService.changeMyLike(1L, 1L, true, 2L))
-        .isInstanceOf(NotAuthorizedOrExistException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> commentLikeService.changeMyLike(1L, 1L, true, 2L))
+            .isInstanceOf(NotAuthorizedOrExistException.class);
+    }
 
-  private Article createArticle(Long memberId, boolean privateMap, boolean publicMap) {
-    return Article.builder().id(1L).content("ddddd").latitude(10.1).longitude(10.1)
-        .private_map(privateMap).public_map(publicMap).title("히히히히").member_id(memberId).build();
-  }
+    private Article createArticle(Long memberId, boolean privateMap, boolean publicMap) {
+        return Article.builder().id(1L).content("ddddd").latitude(10.1).longitude(10.1)
+            .private_map(privateMap).public_map(publicMap).title("히히히히").member_id(memberId)
+            .build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/ChangeImportantServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/ChangeImportantServiceTest.java
@@ -19,22 +19,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ChangeImportantServiceTest {
 
-  @Mock
-  private MemberGroupRepository memberGroupRepository;
+    @Mock
+    private MemberGroupRepository memberGroupRepository;
 
-  @InjectMocks
-  private ChangeImportantService changeImportantService;
+    @InjectMocks
+    private ChangeImportantService changeImportantService;
 
-  @Test
-  @DisplayName("즐겨찾기 변경 - 예외 발생시")
-  public void changeImportant() {
-    //given
-    given(memberGroupRepository.changeImportant(any(), any()))
-        .willReturn(0);
+    @Test
+    @DisplayName("즐겨찾기 변경 - 예외 발생시")
+    public void changeImportant() {
+        //given
+        given(memberGroupRepository.changeImportant(any(), any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> changeImportantService.changeImportant(1L, 1L))
-        .isInstanceOf(NotAuthorizedOrExistException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> changeImportantService.changeImportant(1L, 1L))
+            .isInstanceOf(NotAuthorizedOrExistException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/CreateGroupServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/CreateGroupServiceTest.java
@@ -16,41 +16,41 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 public class CreateGroupServiceTest {
 
-  @Autowired
-  private GroupRepository groupRepository;
+    @Autowired
+    private GroupRepository groupRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
-  @Autowired
-  private CreateGroupService createGroupService;
+    @Autowired
+    private CreateGroupService createGroupService;
 
-  @Test
-  public void createGroup() {
-    //given
-    Member creator = buildMember();
-    String groupName = "테스트 그룹";
+    @Test
+    public void createGroup() {
+        //given
+        Member creator = buildMember();
+        String groupName = "테스트 그룹";
 
-    //when
-    Long groupId = createGroupService.createGroup(groupName, creator.getId());
+        //when
+        Long groupId = createGroupService.createGroup(groupName, creator.getId());
 
-    //then
-    assertThat(groupId).isNotNull();
-    assertThat(groupRepository.findById(groupId).get().getInvitation_code()).isNotNull();
-  }
+        //then
+        assertThat(groupId).isNotNull();
+        assertThat(groupRepository.findById(groupId).get().getInvitation_code()).isNotNull();
+    }
 
-  private Member buildMember() {
-    Member member = Member.builder()
-        .id(20L)
-        .email("test")
-        .image_url(null)
-        .provider_id("test")
-        .provider(AuthProvider.google)
-        .nick_name("tset")
-        .role(Role.USER)
-        .join_date(new Date())
-        .password("password").build();
-    memberRepository.saveMember(member);
-    return member;
-  }
+    private Member buildMember() {
+        Member member = Member.builder()
+            .id(20L)
+            .email("test")
+            .image_url(null)
+            .provider_id("test")
+            .provider(AuthProvider.google)
+            .nick_name("tset")
+            .role(Role.USER)
+            .join_date(new Date())
+            .password("password").build();
+        memberRepository.saveMember(member);
+        return member;
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/DeportMemberServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/DeportMemberServiceTest.java
@@ -22,46 +22,47 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class DeportMemberServiceTest {
 
-  @Mock
-  private MemberGroupRepository memberGroupRepository;
+    @Mock
+    private MemberGroupRepository memberGroupRepository;
 
-  @Mock
-  private GroupRepository groupRepository;
+    @Mock
+    private GroupRepository groupRepository;
 
-  @InjectMocks
-  private DeportMemberService deportMemberService;
+    @InjectMocks
+    private DeportMemberService deportMemberService;
 
-  @Test
-  @DisplayName("그룹원 추방 - 그룹의 주인이 아닐 시")
-  public void deport_IfGroupIsNotMine() {
-    //given
-    Long ownerId = 12L;
-    Group group = buildGroup(1000L);
-    given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
+    @Test
+    @DisplayName("그룹원 추방 - 그룹의 주인이 아닐 시")
+    public void deport_IfGroupIsNotMine() {
+        //given
+        Long ownerId = 12L;
+        Group group = buildGroup(1000L);
+        given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
 
-    //when & then
-    assertThatThrownBy(
-        () -> deportMemberService.deport(1L, 1L, ownerId))
-        .isInstanceOf(NotMatchMemberException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> deportMemberService.deport(1L, 1L, ownerId))
+            .isInstanceOf(NotMatchMemberException.class);
+    }
 
-  @Test
-  @DisplayName("그룹원 추방 - 그룹원이 존재하지 않을 시")
-  public void deport_IfMemberNotExists() {
-    //given
-    Long ownerId = 12L;
-    Group group = buildGroup(ownerId);
-    given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
-    given(memberGroupRepository.deleteMemberGroup(any(), any())).willReturn(0);
+    @Test
+    @DisplayName("그룹원 추방 - 그룹원이 존재하지 않을 시")
+    public void deport_IfMemberNotExists() {
+        //given
+        Long ownerId = 12L;
+        Group group = buildGroup(ownerId);
+        given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
+        given(memberGroupRepository.deleteMemberGroup(any(), any())).willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> deportMemberService.deport(1L, 1L, ownerId))
-        .isInstanceOf(NotExistsException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> deportMemberService.deport(1L, 1L, ownerId))
+            .isInstanceOf(NotExistsException.class);
+    }
 
-  private Group buildGroup(Long ownerId) {
-    return Group.builder().create_date(new Date()).name("test_group").invitation_code("testCode")
-        .owner_id(ownerId).build();
-  }
+    private Group buildGroup(Long ownerId) {
+        return Group.builder().create_date(new Date()).name("test_group")
+            .invitation_code("testCode")
+            .owner_id(ownerId).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/EditGroupNameServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/EditGroupNameServiceTest.java
@@ -17,21 +17,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class EditGroupNameServiceTest {
 
-  @Mock
-  private GroupRepository groupRepository;
+    @Mock
+    private GroupRepository groupRepository;
 
-  @InjectMocks
-  private EditGroupNameService editGroupNameService;
+    @InjectMocks
+    private EditGroupNameService editGroupNameService;
 
-  @Test
-  @DisplayName("예외 발생 테스트")
-  public void change() {
-    //given
-    given(groupRepository.changeGroupName(any(), any(), any())).willReturn(0);
+    @Test
+    @DisplayName("예외 발생 테스트")
+    public void change() {
+        //given
+        given(groupRepository.changeGroupName(any(), any(), any())).willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> editGroupNameService.change(any(), any(), any()))
-        .isInstanceOf(NotAuthorizedOrExistException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> editGroupNameService.change(any(), any(), any()))
+            .isInstanceOf(NotAuthorizedOrExistException.class);
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/JoinGroupServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/JoinGroupServiceTest.java
@@ -22,53 +22,53 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class JoinGroupServiceTest {
 
-  @Mock
-  private GroupRepository groupRepository;
+    @Mock
+    private GroupRepository groupRepository;
 
-  @Mock
-  private MemberGroupRepository memberGroupRepository;
+    @Mock
+    private MemberGroupRepository memberGroupRepository;
 
-  @InjectMocks
-  private JoinGroupService joinGroupService;
+    @InjectMocks
+    private JoinGroupService joinGroupService;
 
-  @Test
-  @DisplayName("그룹 가입")
-  public void join() {
-    //given
-    Group group = buildGroup();
-    given(groupRepository.findByInvitationCode(any()))
-        .willReturn(Optional.ofNullable(group));
-    given(memberGroupRepository.checkAlreadyJoined(any(), any()))
-        .willReturn(false);
+    @Test
+    @DisplayName("그룹 가입")
+    public void join() {
+        //given
+        Group group = buildGroup();
+        given(groupRepository.findByInvitationCode(any()))
+            .willReturn(Optional.ofNullable(group));
+        given(memberGroupRepository.checkAlreadyJoined(any(), any()))
+            .willReturn(false);
 
-    //when
-    Long result = joinGroupService.join("test", group.getId());
+        //when
+        Long result = joinGroupService.join("test", group.getId());
 
-    //then
-    assertThat(result).isEqualTo(group.getId());
-  }
+        //then
+        assertThat(result).isEqualTo(group.getId());
+    }
 
-  @Test
-  @DisplayName("그룹 가입 - 이미 가입되어있는경우")
-  public void join_IfAlreadyJoined() {
-    //given
-    Group group = buildGroup();
-    given(groupRepository.findByInvitationCode(any()))
-        .willReturn(Optional.ofNullable(group));
-    given(memberGroupRepository.checkAlreadyJoined(any(), any()))
-        .willReturn(true);
+    @Test
+    @DisplayName("그룹 가입 - 이미 가입되어있는경우")
+    public void join_IfAlreadyJoined() {
+        //given
+        Group group = buildGroup();
+        given(groupRepository.findByInvitationCode(any()))
+            .willReturn(Optional.ofNullable(group));
+        given(memberGroupRepository.checkAlreadyJoined(any(), any()))
+            .willReturn(true);
 
-    //when & then
-    assertThatThrownBy(
-        () -> joinGroupService.join("test", group.getId()))
-        .isInstanceOf(AlreadyJoinedException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> joinGroupService.join("test", group.getId()))
+            .isInstanceOf(AlreadyJoinedException.class);
+    }
 
-  private Group buildGroup() {
-    return Group.builder()
-        .create_date(new Date())
-        .name("test_group")
-        .invitation_code("testCode")
-        .owner_id(1L).build();
-  }
+    private Group buildGroup() {
+        return Group.builder()
+            .create_date(new Date())
+            .name("test_group")
+            .invitation_code("testCode")
+            .owner_id(1L).build();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
@@ -21,59 +21,59 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class SecessionGroupServiceTest {
 
-  @Spy
-  private GroupRepository groupRepository;
+    @Spy
+    private GroupRepository groupRepository;
 
-  @Mock
-  private MemberGroupRepository memberGroupRepository;
+    @Mock
+    private MemberGroupRepository memberGroupRepository;
 
-  @InjectMocks
-  private SecessionGroupService secessionGroupService;
+    @InjectMocks
+    private SecessionGroupService secessionGroupService;
 
-  @Test
-  @DisplayName("그룹 탈퇴 - 그룹 삭제 x")
-  public void secessionGroup() {
-    //given
-    given(memberGroupRepository.deleteMemberGroup(any(), any()))
-        .willReturn(1);
-    given(memberGroupRepository.countMemberGroup(any()))
-        .willReturn(1L);
+    @Test
+    @DisplayName("그룹 탈퇴 - 그룹 삭제 x")
+    public void secessionGroup() {
+        //given
+        given(memberGroupRepository.deleteMemberGroup(any(), any()))
+            .willReturn(1);
+        given(memberGroupRepository.countMemberGroup(any()))
+            .willReturn(1L);
 
-    //when
-    secessionGroupService.secessionGroup(1L, 1L);
+        //when
+        secessionGroupService.secessionGroup(1L, 1L);
 
-    //then
-    verify(groupRepository, times(0)).deleteById(any());
-  }
+        //then
+        verify(groupRepository, times(0)).deleteById(any());
+    }
 
-  @Test
-  @DisplayName("그룹 탈퇴 - 해당하는 그룹이 없거나 가입이 안되어있을 때")
-  public void secessionGroup_IfNotExistsGroup() {
-    //given
-    given(memberGroupRepository.deleteMemberGroup(any(), any()))
-        .willReturn(0);
+    @Test
+    @DisplayName("그룹 탈퇴 - 해당하는 그룹이 없거나 가입이 안되어있을 때")
+    public void secessionGroup_IfNotExistsGroup() {
+        //given
+        given(memberGroupRepository.deleteMemberGroup(any(), any()))
+            .willReturn(0);
 
-    //when & then
-    assertThatThrownBy(
-        () -> secessionGroupService.secessionGroup(1L, 1L))
-        .isInstanceOf(NotExistsException.class);
-  }
+        //when & then
+        assertThatThrownBy(
+            () -> secessionGroupService.secessionGroup(1L, 1L))
+            .isInstanceOf(NotExistsException.class);
+    }
 
-  @Test
-  @DisplayName("그룹 탈퇴 - 탈퇴 후 그룹에 남은 인원이 없을 시")
-  public void secessionGroup_IfMemberIsNotExists() {
-    //given
-    given(memberGroupRepository.deleteMemberGroup(any(), any()))
-        .willReturn(1);
-    given(memberGroupRepository.countMemberGroup(any()))
-        .willReturn(0L);
-    given(groupRepository.deleteById(any()))
-        .willReturn(1);
+    @Test
+    @DisplayName("그룹 탈퇴 - 탈퇴 후 그룹에 남은 인원이 없을 시")
+    public void secessionGroup_IfMemberIsNotExists() {
+        //given
+        given(memberGroupRepository.deleteMemberGroup(any(), any()))
+            .willReturn(1);
+        given(memberGroupRepository.countMemberGroup(any()))
+            .willReturn(0L);
+        given(groupRepository.deleteById(any()))
+            .willReturn(1);
 
-    //when
-    secessionGroupService.secessionGroup(1L, 1L);
+        //when
+        secessionGroupService.secessionGroup(1L, 1L);
 
-    //then
-    verify(groupRepository, times(1)).deleteById(any());
-  }
+        //then
+        verify(groupRepository, times(1)).deleteById(any());
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/member/AuthServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/member/AuthServiceTest.java
@@ -31,114 +31,117 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
 
-  @Mock
-  private MemberRepository memberRepository;
+    @Mock
+    private MemberRepository memberRepository;
 
-  @Spy
-  private PasswordEncoder passwordEncoder = new MockPasswordEncoder();
+    @Spy
+    private PasswordEncoder passwordEncoder = new MockPasswordEncoder();
 
-  @Mock
-  private JwtTokenProvider tokenProvider;
+    @Mock
+    private JwtTokenProvider tokenProvider;
 
-  @Spy
-  @InjectMocks
-  private AuthService authService;
+    @Spy
+    @InjectMocks
+    private AuthService authService;
 
-  private Member member;
+    private Member member;
 
-  @Test
-  @DisplayName("로그인시")
-  public void Login() {
-    //given
-    String testToken = "testtset";
-    setUser();
-    LoginRequest loginRequest = new LoginRequest("email", "password");
-    given(memberRepository.findByEmail("email")).willReturn(Optional.ofNullable(member));
-    given(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())).willReturn(true);
-    given(tokenProvider.createAccessToken(any(), any())).willReturn(testToken);
+    @Test
+    @DisplayName("로그인시")
+    public void Login() {
+        //given
+        String testToken = "testtset";
+        setUser();
+        LoginRequest loginRequest = new LoginRequest("email", "password");
+        given(memberRepository.findByEmail("email")).willReturn(Optional.ofNullable(member));
+        given(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())).willReturn(
+            true);
+        given(tokenProvider.createAccessToken(any(), any())).willReturn(testToken);
 
-    //when
-    String token = authService.login(loginRequest);
+        //when
+        String token = authService.login(loginRequest);
 
-    //then
-    assertThat(token).isEqualTo(testToken);
-  }
-
-  @Test
-  @DisplayName("로그인 실패할 경우")
-  public void Login_IfNotExistsEmail() {
-    //given
-    LoginRequest loginRequest = new LoginRequest("email", "password");
-
-    //when & then
-    assertThatThrownBy(
-        () -> authService.login(loginRequest))
-        .isInstanceOf(NotExistsException.class);
-
-    //given
-    setUser();
-    given(memberRepository.findByEmail("email")).willReturn(Optional.ofNullable(member));
-    given(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())).willReturn(false);
-
-    //when & then
-    assertThatThrownBy(
-        () -> authService.login(loginRequest))
-        .isInstanceOf(NotMatchPasswordException.class);
-  }
-
-  @Test
-  @DisplayName("회원가입 진행시")
-  public void SignUp() {
-    //given
-    ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
-    SignUpRequest signUpRequest = new SignUpRequest("nickName", "email", "password");
-    given(memberRepository.saveMember(any())).willReturn(1L);
-    given(memberRepository.existsByEmail("email")).willReturn(false);
-
-    //when
-    authService.signUp(signUpRequest);
-
-    //then
-    verify(memberRepository, times(1)).saveMember(captor.capture());
-    Member member = captor.getValue();
-    assertThat(signUpRequest.getNickName()).isEqualTo(member.getNick_name());
-  }
-
-  @Test
-  @DisplayName("회원가입 진행시 이미 이메일이 가입되어 있는경우")
-  public void SignUp_IfExistsEmail() {
-    //given
-    SignUpRequest signUpRequest = new SignUpRequest("nickName", "email", "password");
-    given(memberRepository.existsByEmail("email")).willReturn(true);
-
-    //when & then
-    assertThatThrownBy(
-        () -> authService.signUp(signUpRequest))
-        .isInstanceOf(AlreadyExistedEmailException.class);
-  }
-
-  private void setUser() {
-    member = Member.builder()
-        .id(20L)
-        .email("test")
-        .image_url(null)
-        .provider_id("test")
-        .provider(AuthProvider.google)
-        .nick_name("tset")
-        .role(Role.USER)
-        .join_date(new Date())
-        .password("password").build();
-  }
-
-  private class MockPasswordEncoder implements PasswordEncoder {
-    @Override
-    public String encode(CharSequence rawPassword) {
-      return new StringBuilder(rawPassword).reverse().toString();
+        //then
+        assertThat(token).isEqualTo(testToken);
     }
 
-    @Override
-    public boolean matches(CharSequence rawPassword, String encodedPassword) {
-      return encode(rawPassword).equals(encodedPassword);
+    @Test
+    @DisplayName("로그인 실패할 경우")
+    public void Login_IfNotExistsEmail() {
+        //given
+        LoginRequest loginRequest = new LoginRequest("email", "password");
+
+        //when & then
+        assertThatThrownBy(
+            () -> authService.login(loginRequest))
+            .isInstanceOf(NotExistsException.class);
+
+        //given
+        setUser();
+        given(memberRepository.findByEmail("email")).willReturn(Optional.ofNullable(member));
+        given(passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())).willReturn(
+            false);
+
+        //when & then
+        assertThatThrownBy(
+            () -> authService.login(loginRequest))
+            .isInstanceOf(NotMatchPasswordException.class);
     }
-  }
+
+    @Test
+    @DisplayName("회원가입 진행시")
+    public void SignUp() {
+        //given
+        ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+        SignUpRequest signUpRequest = new SignUpRequest("nickName", "email", "password");
+        given(memberRepository.saveMember(any())).willReturn(1L);
+        given(memberRepository.existsByEmail("email")).willReturn(false);
+
+        //when
+        authService.signUp(signUpRequest);
+
+        //then
+        verify(memberRepository, times(1)).saveMember(captor.capture());
+        Member member = captor.getValue();
+        assertThat(signUpRequest.getNickName()).isEqualTo(member.getNick_name());
+    }
+
+    @Test
+    @DisplayName("회원가입 진행시 이미 이메일이 가입되어 있는경우")
+    public void SignUp_IfExistsEmail() {
+        //given
+        SignUpRequest signUpRequest = new SignUpRequest("nickName", "email", "password");
+        given(memberRepository.existsByEmail("email")).willReturn(true);
+
+        //when & then
+        assertThatThrownBy(
+            () -> authService.signUp(signUpRequest))
+            .isInstanceOf(AlreadyExistedEmailException.class);
+    }
+
+    private void setUser() {
+        member = Member.builder()
+            .id(20L)
+            .email("test")
+            .image_url(null)
+            .provider_id("test")
+            .provider(AuthProvider.google)
+            .nick_name("tset")
+            .role(Role.USER)
+            .join_date(new Date())
+            .password("password").build();
+    }
+
+    private class MockPasswordEncoder implements PasswordEncoder {
+
+        @Override
+        public String encode(CharSequence rawPassword) {
+            return new StringBuilder(rawPassword).reverse().toString();
+        }
+
+        @Override
+        public boolean matches(CharSequence rawPassword, String encodedPassword) {
+            return encode(rawPassword).equals(encodedPassword);
+        }
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/member/MemberServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/member/MemberServiceTest.java
@@ -26,52 +26,52 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
 
-  @Spy
-  private MemberRepository memberRepository;
+    @Spy
+    private MemberRepository memberRepository;
 
-  @Spy
-  @InjectMocks
-  private MemberService memberService;
+    @Spy
+    @InjectMocks
+    private MemberService memberService;
 
-  private Member member;
+    private Member member;
 
-  @Test
-  public void findImageUrl() {
-    //given
-    setMember();
-    given(memberRepository.findById(any())).willReturn(Optional.ofNullable(member));
+    @Test
+    public void findImageUrl() {
+        //given
+        setMember();
+        given(memberRepository.findById(any())).willReturn(Optional.ofNullable(member));
 
-    //when
-    MemberImageResponse response = memberService.findImageUrl(member.getId());
+        //when
+        MemberImageResponse response = memberService.findImageUrl(member.getId());
 
-    //then
-    verify(memberRepository, times(1)).findById(any());
-    verify(memberService, times(1)).findImageUrl(any());
-    assertThat(response.getImageUrl()).isNull();
-    assertThat(response.getMemberId()).isEqualTo(member.getId());
-  }
+        //then
+        verify(memberRepository, times(1)).findById(any());
+        verify(memberService, times(1)).findImageUrl(any());
+        assertThat(response.getImageUrl()).isNull();
+        assertThat(response.getMemberId()).isEqualTo(member.getId());
+    }
 
-  @Test
-  @DisplayName("해당하는 회원이 존재하지 않을 때")
-  public void findImageUr_IfNotExistsMember() {
-    //given
-    Long memberId = 1L;
-    //when & then
-    assertThatThrownBy(
-        () -> memberService.findImageUrl(memberId))
-        .isInstanceOf(NotExistsException.class);
-  }
+    @Test
+    @DisplayName("해당하는 회원이 존재하지 않을 때")
+    public void findImageUr_IfNotExistsMember() {
+        //given
+        Long memberId = 1L;
+        //when & then
+        assertThatThrownBy(
+            () -> memberService.findImageUrl(memberId))
+            .isInstanceOf(NotExistsException.class);
+    }
 
-  private void setMember() {
-    member = Member.builder()
-        .id(20L)
-        .email("test")
-        .image_url(null)
-        .provider_id("test")
-        .provider(AuthProvider.google)
-        .nick_name("tset")
-        .role(Role.USER)
-        .join_date(new Date())
-        .password("password").build();
-  }
+    private void setMember() {
+        member = Member.builder()
+            .id(20L)
+            .email("test")
+            .image_url(null)
+            .provider_id("test")
+            .provider(AuthProvider.google)
+            .nick_name("tset")
+            .role(Role.USER)
+            .join_date(new Date())
+            .password("password").build();
+    }
 }


### PR DESCRIPTION
resolved: #58 
마이페이지 찾기 기능을 구현한다.
마이페이지 찾는 get api 요청시 내 정보, 내가 작성한 게시글 리스트(게시글 아이디, 제목, 날짜, 총 좋아요 수, 총 댓글 수), 내가 들어가 있는 그룹 리스트(그룹 아이디, 그룹 이름)를 리턴하도록 하였다.
resultMap에 collection을 활요하여 1번의 db조회로 모든 정보를 가져오도록 하였다.