### PR TITLE
refactor: findGroupMapArticles 시 그룹이름도 가져오도록 수정

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/article/api/FindArticleController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/api/FindArticleController.java
@@ -6,6 +6,7 @@ import foot.footprint.domain.article.dto.ArticleMapResponse;
 import foot.footprint.domain.article.dto.ArticlePageResponse;
 import foot.footprint.domain.article.dto.ArticleRangeRequest;
 import foot.footprint.domain.article.application.FindArticleService;
+import foot.footprint.domain.article.dto.GroupMapArticlesDto;
 import foot.footprint.global.error.exception.WrongInputException;
 import foot.footprint.global.security.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -48,14 +49,14 @@ public class FindArticleController {
     }
 
     @GetMapping("/grouped")
-    public ResponseEntity<List<ArticleMapResponse>> findGroupedMapArticles(
+    public ResponseEntity<GroupMapArticlesDto> findGroupedMapArticles(
         @RequestParam(value = "groupId") Long groupId, ArticleRangeRequest request,
         @AuthenticationPrincipal CustomUserDetails userDetails) {
         validateLocation(request);
         LocationRange locationRange = new LocationRange(request);
-        List<ArticleMapResponse> groupedMapArticles = findArticleService.findGroupedArticles(
+        GroupMapArticlesDto groupedArticles = findArticleService.findGroupedArticles(
             userDetails.getId(), groupId, locationRange);
-        return ResponseEntity.ok().body(groupedMapArticles);
+        return ResponseEntity.ok().body(groupedArticles);
     }
 
     private void validateLocation(ArticleRangeRequest request) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/FindArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/FindArticleService.java
@@ -4,7 +4,8 @@ import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.dto.ArticleMapResponse;
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.LocationRange;
-import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.domain.article.dto.GroupMapArticlesDto;
+import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.global.error.exception.NotExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,37 +18,34 @@ public class FindArticleService {
 
     private final FindArticleRepository findArticleRepository;
 
-    private final MemberGroupRepository memberGroupRepository;
+    private final GroupRepository groupRepository;
 
     @Transactional(readOnly = true)
-    public List<ArticleMapResponse> findPublicMapArticles(
-        LocationRange locationRange) {
+    public List<ArticleMapResponse> findPublicMapArticles(LocationRange locationRange) {
         Long memberId = null;
         return ArticleMapResponse.toResponses(findArticles(memberId, locationRange));
     }
 
     @Transactional(readOnly = true)
-    public List<ArticleMapResponse> findPrivateMapArticles(
-        Long memberId, LocationRange locationRange) {
+    public List<ArticleMapResponse> findPrivateMapArticles(Long memberId,
+        LocationRange locationRange) {
         return ArticleMapResponse.toResponses(findArticles(memberId, locationRange));
     }
 
     @Transactional(readOnly = true)
-    public List<ArticleMapResponse> findGroupedArticles(
-        Long memberId, Long groupId, LocationRange locationRange) {
-        validateHasJoined(groupId, memberId);
+    public GroupMapArticlesDto findGroupedArticles(Long memberId, Long groupId,
+        LocationRange locationRange) {
+        String groupName = findGroupName(groupId, memberId);
         List<Article> articles = findArticleRepository.findArticlesByGroup(groupId, locationRange);
-        return ArticleMapResponse.toResponses(articles);
+        return new GroupMapArticlesDto(ArticleMapResponse.toResponses(articles), groupName);
     }
 
     private List<Article> findArticles(Long memberId, LocationRange locationRange) {
         return findArticleRepository.findArticles(memberId, locationRange);
     }
 
-    private void validateHasJoined(Long groupId, Long memberId) {
-        boolean isPresent = memberGroupRepository.checkAlreadyJoined(groupId, memberId);
-        if (!isPresent) {
-            throw new NotExistsException("그룹에 속해있지 않습니다.");
-        }
+    private String findGroupName(Long groupId, Long memberId) {
+        return groupRepository.findGroupName(memberId, groupId)
+            .orElseThrow(() -> new NotExistsException("그룹에 속해있지 않거나 해당되는 그룹이 존재하지 않습니다."));
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/GroupMapArticlesDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/GroupMapArticlesDto.java
@@ -1,0 +1,15 @@
+package foot.footprint.domain.article.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupMapArticlesDto {
+
+    List<ArticleMapResponse> responses;
+    String groupName;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
@@ -31,4 +31,6 @@ public interface GroupRepository {
     List<Long> findAllByMemberId(Long memberId);
 
     Optional<GroupDetailsResponse> findGroupDetails(Long groupId, Long memberId);
+
+    Optional<String> findGroupName(Long memberId, Long groupId);
 }

--- a/backend/footprint/src/main/resources/mapper/group/GroupMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/group/GroupMapper.xml
@@ -7,6 +7,10 @@
     create_date, invitation_code, name, owner_id
     ) VALUES (#{create_date}, #{invitation_code}, #{name}, #{owner_id})
   </insert>
+  <select id="findGroupName" resultType="String">
+    select g.name from group_table g join member_group m on (g.id = m.group_id)
+    where m.member_id = #{memberId} and g.id = #{groupId}
+  </select>
   <select id="findAllByMemberId" resultType="Long">
     select g.id from group_table g join member_group m on (g.id = m.group_id)
     where m.member_id = #{memberId}

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
@@ -170,6 +170,28 @@ public class GroupRepositoryTest extends RepositoryTest {
         assertThat(response4.get().getId()).isEqualTo(group.getId());
     }
 
+    @Test
+    public void findGroupName(){
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group = buildGroup(member.getId());
+        groupRepository.saveGroup(group);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
+
+        //when
+        Optional<String> name = groupRepository.findGroupName(member.getId(), group.getId());
+        Optional<String> emptyName1 = groupRepository.findGroupName(member.getId(), 14L);
+        Optional<String> emptyName2 = groupRepository.findGroupName(30L, group.getId());
+
+        //then
+        assertThat(name.isPresent()).isTrue();
+        assertThat(name.get()).isEqualTo(group.getName());
+        assertThat(emptyName1.isPresent()).isFalse();
+        assertThat(emptyName2.isPresent()).isFalse();
+    }
+
     private Group buildGroup(Long ownerId, String invitationCode) {
         return Group.builder().create_date(new Date()).name("test_group")
             .invitation_code(invitationCode).owner_id(ownerId).build();

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleServiceTest.java
@@ -6,8 +6,10 @@ import foot.footprint.domain.article.domain.LocationRange;
 import foot.footprint.domain.article.dto.ArticleMapResponse;
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.dto.ArticleRangeRequest;
-import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.domain.article.dto.GroupMapArticlesDto;
+import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.global.error.exception.NotExistsException;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +35,7 @@ public class FindArticleServiceTest {
     private FindArticleRepository findArticleRepository;
 
     @Mock
-    private MemberGroupRepository memberGroupRepository;
+    private GroupRepository groupRepository;
 
     @Spy
     @InjectMocks
@@ -63,18 +65,20 @@ public class FindArticleServiceTest {
     @DisplayName("그룹지도")
     public void groupedMapArticlesTest() {
         //given
+        String groupName = "테스트입니다.";
         List<Article> articles = createArticleList(createArticle());
         LocationRange locationRange = new LocationRange(
             new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
-        given(memberGroupRepository.checkAlreadyJoined(any(), any())).willReturn(true);
+        given(groupRepository.findGroupName(any(), any())).willReturn(Optional.of(groupName));
         given(findArticleRepository.findArticlesByGroup(1L, locationRange)).willReturn(articles);
 
         //when
-        List<ArticleMapResponse> result = findArticleService.findGroupedArticles(1L, 1L,
+        GroupMapArticlesDto result = findArticleService.findGroupedArticles(1L, 1L,
             locationRange);
 
         //then
-        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.getResponses().size()).isEqualTo(1);
+        assertThat(result.getGroupName()).isEqualTo(groupName);
     }
 
     @Test
@@ -83,7 +87,6 @@ public class FindArticleServiceTest {
         //given
         LocationRange locationRange = new LocationRange(
             new ArticleRangeRequest(10.0, 10.0, 10.0, 10.0));
-        given(memberGroupRepository.checkAlreadyJoined(any(), any())).willReturn(false);
 
         //when & then
         assertThatThrownBy(


### PR DESCRIPTION
resolved: #60 
이전 프로젝트에서 홈 화면 상에 groupArticles를 확인할 때 우측 위에 groupName를 표시해놓는데 그 요청 api 따로 구현되있다. 그렇기에 findGroupArticles 요청에 groupName 필드를 추가하여 2번 요청하는 일이 생기지 않도록 한다.