### PR TITLE
refactor: 그룹의 주인이 탈퇴 시 그룹 주인을 변경시키도록 수정

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/SecessionGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/SecessionGroupService.java
@@ -2,11 +2,17 @@ package foot.footprint.domain.group.application;
 
 import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.domain.group.domain.Group;
+import foot.footprint.domain.group.domain.MemberGroup;
 import foot.footprint.global.error.exception.NotExistsException;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SecessionGroupService {
@@ -17,21 +23,47 @@ public class SecessionGroupService {
 
     @Transactional
     public void secessionGroup(Long groupId, Long memberId) {
+        Group group = findGroup(groupId);
+        if (group.getOwner_id().equals(memberId)) {
+            checkRemainingMember(groupId, memberId);
+            return;
+        }
         deleteMemberGroup(groupId, memberId);
-        deleteGroupIfMemberIsNotExist(groupId);
+    }
+
+    private Group findGroup(Long groupId) {
+        return groupRepository.findById(groupId)
+            .orElseThrow(() -> new NotExistsException("해당되는 그룹이 존재하지 않습니다."));
+    }
+
+    private void checkRemainingMember(Long groupId, Long memberId) {
+        List<MemberGroup> memberGroups = memberGroupRepository.findAllByGroupId(groupId);
+        //owner 만 그룹에 남아있을 경우
+        if (memberGroups.size() == 1) {
+            groupRepository.deleteById(groupId);
+            log.info(groupId + " 그룹이 삭제되었습니다.");
+            return;
+        }
+        updateOwner(groupId, memberId, memberGroups);
+    }
+
+    private void updateOwner(Long groupId, Long memberId, List<MemberGroup> memberGroups) {
+        MemberGroup nextMemberGroup = findNextOwner(memberGroups, memberId);
+        Long nextOwnerId = nextMemberGroup.getMember_id();
+        groupRepository.updateOwner(groupId, nextOwnerId);
+        deleteMemberGroup(groupId, memberId);
+    }
+
+    private MemberGroup findNextOwner(List<MemberGroup> memberGroups, Long memberId) {
+        return memberGroups.stream()
+            .filter(memberGroup -> !Objects.equals(memberGroup.getMember_id(), memberId))
+            .findFirst().orElseThrow(() -> new NotExistsException("해당되는 회원이 존재하지 않습니다."));
     }
 
     private void deleteMemberGroup(Long groupId, Long memberId) {
         int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
         if (deleted == 0) {
             throw new NotExistsException("이미 탈퇴한 그룹이거나 존재하지 않는 그룹입니다.");
-        }
-    }
-
-    private void deleteGroupIfMemberIsNotExist(Long groupId) {
-        Long memberCount = memberGroupRepository.countMemberGroup(groupId);
-        if (memberCount <= 0) {
-            groupRepository.deleteById(groupId);
         }
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/GroupRepository.java
@@ -33,4 +33,7 @@ public interface GroupRepository {
     Optional<GroupDetailsResponse> findGroupDetails(Long groupId, Long memberId);
 
     Optional<String> findGroupName(Long memberId, Long groupId);
+
+    @Update("UPDATE group_table SET owner_id = #{memberId} WHERE id = #{groupId}")
+    int updateOwner(Long groupId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.group.dao;
 import foot.footprint.domain.group.domain.MemberGroup;
 import foot.footprint.domain.group.dto.GroupSummaryResponse;
 import java.util.List;
+import java.util.Optional;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
@@ -23,7 +24,7 @@ public interface MemberGroupRepository {
     int changeImportant(Long groupId, Long memberId);
 
     @Select("SELECT * FROM member_group WHERE id=#{id}")
-    MemberGroup findById(Long id);
+    Optional<MemberGroup> findById(Long id);
 
     List<GroupSummaryResponse> findMyImportantGroups(Long memberId);
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
@@ -29,4 +29,7 @@ public interface MemberGroupRepository {
     List<GroupSummaryResponse> findMyImportantGroups(Long memberId);
 
     List<GroupSummaryResponse> findMyGroups(Long memberId);
+
+    @Select("SELECT * FROM member_group WHERE group_id = #{groupId} ORDER BY id")
+    List<MemberGroup> findAllByGroupId(Long groupId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/domain/MemberGroup.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/domain/MemberGroup.java
@@ -45,10 +45,6 @@ public class MemberGroup {
     }
 
     public void changeImportant() {
-        if (Objects.isNull(important)) {
-            important = true;
-        } else {
-            important = !important;
-        }
+        important = !important;
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/GroupRepositoryTest.java
@@ -81,12 +81,18 @@ public class GroupRepositoryTest extends RepositoryTest {
         Group group = Group.builder().create_date(new Date()).name("test_group")
             .invitation_code(invitationCode).owner_id(1L).build();
         groupRepository.saveGroup(group);
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        MemberGroup memberGroup = buildMemberGroup(group.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup);
 
         //when & then
         assertThat(groupRepository.findById(group.getId())).isPresent();
+        assertThat(memberGroupRepository.findById(memberGroup.getId())).isPresent();
         int result = groupRepository.deleteById(group.getId());
         int dummy = groupRepository.deleteById(200L);
         assertThat(groupRepository.findById(group.getId())).isNotPresent();
+        assertThat(memberGroupRepository.findById(memberGroup.getId())).isNotPresent();
         assertThat(result).isEqualTo(1);
         assertThat(dummy).isEqualTo(0);
     }
@@ -171,7 +177,7 @@ public class GroupRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    public void findGroupName(){
+    public void findGroupName() {
         //given
         Member member = buildMember();
         memberRepository.saveMember(member);

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -12,6 +12,7 @@ import foot.footprint.domain.member.domain.Member;
 import foot.footprint.repository.RepositoryTest;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -127,11 +128,11 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
         //when & then
         assertThat(memberGroup.isImportant()).isTrue();
         memberGroupRepository.changeImportant(group.getId(), member.getId());
-        MemberGroup changedMemberGroup = memberGroupRepository.findById(member.getId());
-        assertThat(changedMemberGroup.isImportant()).isFalse();
+        Optional<MemberGroup> changedMemberGroup = memberGroupRepository.findById(member.getId());
+        assertThat(changedMemberGroup.get().isImportant()).isFalse();
         memberGroupRepository.changeImportant(group.getId(), member.getId());
-        MemberGroup changedMemberGroup2 = memberGroupRepository.findById(member.getId());
-        assertThat(changedMemberGroup2.isImportant()).isTrue();
+        Optional<MemberGroup> changedMemberGroup2 = memberGroupRepository.findById(member.getId());
+        assertThat(changedMemberGroup2.get().isImportant()).isTrue();
     }
 
     @Test

--- a/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
@@ -1,6 +1,5 @@
 package foot.footprint.service.group;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -9,12 +8,15 @@ import static org.mockito.Mockito.verify;
 import foot.footprint.domain.group.application.SecessionGroupService;
 import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
-import foot.footprint.global.error.exception.NotExistsException;
+import foot.footprint.domain.group.domain.Group;
+import foot.footprint.domain.group.domain.MemberGroup;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -24,56 +26,73 @@ public class SecessionGroupServiceTest {
     @Spy
     private GroupRepository groupRepository;
 
-    @Mock
+    @Spy
     private MemberGroupRepository memberGroupRepository;
 
     @InjectMocks
     private SecessionGroupService secessionGroupService;
 
     @Test
-    @DisplayName("그룹 탈퇴 - 그룹 삭제 x")
-    public void secessionGroup() {
+    @DisplayName("그룹 탈퇴 - 그룹의 주인이 아닐경우")
+    public void secessionGroupIfNotOwner() {
         //given
-        given(memberGroupRepository.deleteMemberGroup(any(), any()))
-            .willReturn(1);
-        given(memberGroupRepository.countMemberGroup(any()))
-            .willReturn(1L);
+        Long groupId = 30L;
+        Long ownerId = 1L;
+        Long accessMemberId = 2L;
+        Group group = SetUpMethods.buildGroup(ownerId);
+        given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
+        given(memberGroupRepository.deleteMemberGroup(any(), any())).willReturn(1);
 
         //when
-        secessionGroupService.secessionGroup(1L, 1L);
+        secessionGroupService.secessionGroup(groupId, accessMemberId);
+
+        //then
+        verify(memberGroupRepository, times(0)).findAllByGroupId(any());
+    }
+
+    @Test
+    @DisplayName("그룹 탈퇴 - 그룹의 주인이고 남은 그룹원이 존재할 경우")
+    public void secessionGroupIfOwner() {
+        //given
+        Long groupId = 30L;
+        Long ownerId = 1L;
+        Long secondMemberId = 2L;
+        Group group = SetUpMethods.buildGroup(ownerId);
+        List<MemberGroup> memberGroups = new ArrayList<>();
+        memberGroups.add(SetUpMethods.buildMemberGroup(groupId, ownerId));
+        memberGroups.add(SetUpMethods.buildMemberGroup(groupId, secondMemberId));
+        given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
+        given(memberGroupRepository.findAllByGroupId(any())).willReturn(memberGroups);
+        given(memberGroupRepository.deleteMemberGroup(any(), any())).willReturn(1);
+        given(groupRepository.updateOwner(any(), any())).willReturn(1);
+
+        //when
+        secessionGroupService.secessionGroup(groupId, ownerId);
 
         //then
         verify(groupRepository, times(0)).deleteById(any());
+        verify(groupRepository, times(1)).updateOwner(any(), any());
+        verify(memberGroupRepository, times(1)).deleteMemberGroup(any(), any());
     }
 
     @Test
-    @DisplayName("그룹 탈퇴 - 해당하는 그룹이 없거나 가입이 안되어있을 때")
-    public void secessionGroup_IfNotExistsGroup() {
+    @DisplayName("그룹 탈퇴 - 그룹의 주인이고 혼자 남았을 경우")
+    public void secessionGroupIfOwnerRemainAlone() {
         //given
-        given(memberGroupRepository.deleteMemberGroup(any(), any()))
-            .willReturn(0);
-
-        //when & then
-        assertThatThrownBy(
-            () -> secessionGroupService.secessionGroup(1L, 1L))
-            .isInstanceOf(NotExistsException.class);
-    }
-
-    @Test
-    @DisplayName("그룹 탈퇴 - 탈퇴 후 그룹에 남은 인원이 없을 시")
-    public void secessionGroup_IfMemberIsNotExists() {
-        //given
-        given(memberGroupRepository.deleteMemberGroup(any(), any()))
-            .willReturn(1);
-        given(memberGroupRepository.countMemberGroup(any()))
-            .willReturn(0L);
-        given(groupRepository.deleteById(any()))
-            .willReturn(1);
+        Long groupId = 30L;
+        Long ownerId = 1L;
+        Group group = SetUpMethods.buildGroup(ownerId);
+        List<MemberGroup> memberGroups = new ArrayList<>();
+        memberGroups.add(SetUpMethods.buildMemberGroup(groupId, ownerId));
+        given(groupRepository.findById(any())).willReturn(Optional.ofNullable(group));
+        given(memberGroupRepository.findAllByGroupId(any())).willReturn(memberGroups);
+        given(groupRepository.deleteById(any())).willReturn(1);
 
         //when
-        secessionGroupService.secessionGroup(1L, 1L);
+        secessionGroupService.secessionGroup(groupId, ownerId);
 
         //then
         verify(groupRepository, times(1)).deleteById(any());
+        verify(memberGroupRepository, times(0)).deleteMemberGroup(any(), any());
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/SetUpMethods.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/SetUpMethods.java
@@ -1,0 +1,68 @@
+package foot.footprint.service.group;
+
+import foot.footprint.domain.article.domain.Article;
+import foot.footprint.domain.articleLike.domain.ArticleLike;
+import foot.footprint.domain.comment.domain.Comment;
+import foot.footprint.domain.group.domain.Group;
+import foot.footprint.domain.group.domain.MemberGroup;
+import foot.footprint.domain.member.domain.AuthProvider;
+import foot.footprint.domain.member.domain.Member;
+import foot.footprint.domain.member.domain.Role;
+import java.util.Date;
+
+public class SetUpMethods {
+    public static Member buildMember() {
+        return Member.builder()
+            .nick_name("nickName")
+            .email("email")
+            .provider(AuthProvider.google)
+            .password("password")
+            .provider_id("test")
+            .image_url(null)
+            .join_date(new Date())
+            .role(Role.USER)
+            .build();
+    }
+
+    public static Article buildArticle(Long memberId) {
+        return Article.builder()
+            .content("test")
+            .latitude(10.0)
+            .longitude(10.0)
+            .public_map(true)
+            .private_map(true)
+            .title("test")
+            .create_date(new Date())
+            .member_id(memberId).build();
+    }
+
+    public static ArticleLike buildArticleLike(Long memberId, Long articleId) {
+        return ArticleLike.builder()
+            .member_id(memberId)
+            .article_id(articleId).build();
+    }
+
+    public static Comment buildComment(Long ownerId, Long articleId) {
+        return Comment.builder()
+            .content("아무내용")
+            .article_id(articleId)
+            .member_id(ownerId)
+            .create_date(new Date()).build();
+    }
+
+    public static Group buildGroup(Long ownerId) {
+        return Group.builder()
+            .create_date(new Date())
+            .name("test_group")
+            .invitation_code("testCode")
+            .owner_id(ownerId).build();
+    }
+
+    public static MemberGroup buildMemberGroup(Long groupId, Long memberId) {
+        return MemberGroup.builder()
+            .create_date(new Date())
+            .group_id(groupId)
+            .member_id(memberId)
+            .important(true).build();
+    }
+}


### PR DESCRIPTION
resolved: #68 

그룹 탈퇴 시 
1. 그룹의 주인이 아닐 경우
2. 그룹의 주인이고 자신만 남았을 경우
3. 그룹의 주인이고 자신 이외에 회원이 남았을 경우

3가지의 경우로 나눠서 구현하고 테스트하였다.

그룹을 찾고 ownerId 비교 -> 아니면 그룹 탈퇴: 2번 DB 접근
그룹을 찾고 ownerId 비교 ->  맞으면 memberGroup을 find 
-> memberGroupList의 사이즈가 1이면 바로 group 삭제:  3번 DB 접근
그룹을 찾고 ownerId 비교 ->  맞으면 memberGroup을 find 
-> memberGroupList의 사이즈가 1보다 크면 업데이트쿼리 실행 -> 그룹 탈퇴:  4번 DB 접근