### PR TITLE
Bug#1: 그룹 관련 에러 수정

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticles/FindGroupedArticles.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticles/FindGroupedArticles.java
@@ -4,6 +4,8 @@ import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.domain.LocationRange;
 import foot.footprint.domain.article.dto.ArticleMapResponse;
+import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.global.error.exception.NotAuthorizedOrExistException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,12 +19,21 @@ public class FindGroupedArticles implements FindArticlesService {
 
     private final FindArticleRepository findArticleRepository;
 
+    private final MemberGroupRepository memberGroupRepository;
+
 
     @Override
     @Transactional(readOnly = true)
     public List<ArticleMapResponse> findArticles(Long memberId, Long groupId,
         LocationRange locationRange) {
+        validateMemberInGroup(memberId, groupId);
         List<Article> articles = findArticleRepository.findArticlesByGroup(groupId, locationRange);
         return ArticleMapResponse.toResponses(articles);
+    }
+
+    private void validateMemberInGroup(Long memberId, Long groupId){
+        if(!memberGroupRepository.existsMemberInGroup(memberId, groupId)){
+            throw new NotAuthorizedOrExistException("해당 그룹에 접근할 권한이 없습니다.");
+        }
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/EditArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/EditArticleRepository.java
@@ -8,4 +8,6 @@ public interface EditArticleRepository {
 
     @Update("UPDATE article SET content=#{content} WHERE id=#{articleId} and member_id=#{memberId}")
     int editArticle(Long articleId, Long memberId, String content);
+
+    int updatePrivateMapTrue(Long memberId, Long groupId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -17,6 +17,9 @@ public interface FindArticleRepository {
 
     List<Article> findArticlesByGroup(Long groupId, LocationRange locationRange);
 
+    @Select("select * from article order by id")
+    List<Article> findAll();
+
     @Select("Select * from article where id=#{articleId}")
     Optional<Article> findById(Long articleId);
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/api/FindGroupController.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/api/FindGroupController.java
@@ -2,6 +2,7 @@ package foot.footprint.domain.group.api;
 
 import foot.footprint.domain.group.application.findGroup.FindGroupService;
 import foot.footprint.domain.group.dto.find.GroupDetailsResponse;
+import foot.footprint.domain.group.dto.find.GroupNameResponse;
 import foot.footprint.domain.group.dto.find.GroupSummaryResponse;
 import foot.footprint.global.security.user.CustomUserDetails;
 import java.util.List;
@@ -41,6 +42,14 @@ public class FindGroupController {
     public ResponseEntity<GroupDetailsResponse> findOne(@PathVariable("id") Long groupId,
         @AuthenticationPrincipal CustomUserDetails userDetails) {
         GroupDetailsResponse response = findGroupService.findOne(groupId, userDetails.getId());
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{id}/name")
+    public ResponseEntity<GroupNameResponse> findGroupName(@PathVariable("id") Long groupId,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        GroupNameResponse response = findGroupService.findName(groupId, userDetails.getId());
 
         return ResponseEntity.ok().body(response);
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/deportMember/DeportMemberServiceImpl.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/deportMember/DeportMemberServiceImpl.java
@@ -1,6 +1,8 @@
 package foot.footprint.domain.group.application.deportMember;
 
+import foot.footprint.domain.article.dao.EditArticleRepository;
 import foot.footprint.domain.article.exception.NotMatchMemberException;
+import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
 import foot.footprint.domain.group.domain.Group;
@@ -18,10 +20,15 @@ public class DeportMemberServiceImpl implements DeportMemberService{
 
     private final GroupRepository groupRepository;
 
+    private final EditArticleRepository editArticleRepository;
+
+    private final ArticleGroupRepository articleGroupRepository;
+
     @Override
     @Transactional
     public void deport(Long groupId, Long memberId, Long myId) {
         validateGroupIsMine(groupId, myId, memberId);
+        organizeArticle(groupId, memberId);
         int deleted = memberGroupRepository.deleteMemberGroup(groupId, memberId);
         if (deleted == 0) {
             throw new NotExistsException("해당인원이 그룹에 이미 존재하지 않습니다.");
@@ -37,5 +44,10 @@ public class DeportMemberServiceImpl implements DeportMemberService{
         if (!Objects.equals(group.getOwner_id(), myId)) {
             throw new NotMatchMemberException("그룹원을 추방시킬 권한이 없습니다.");
         }
+    }
+
+    private void organizeArticle(Long groupId, Long memberId){
+        editArticleRepository.updatePrivateMapTrue(memberId, groupId);
+        articleGroupRepository.deleteArticleGroup(memberId, groupId);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/findGroup/FindGroupService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/findGroup/FindGroupService.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.group.application.findGroup;
 
 import foot.footprint.domain.group.dto.find.GroupDetailsResponse;
+import foot.footprint.domain.group.dto.find.GroupNameResponse;
 import foot.footprint.domain.group.dto.find.GroupSummaryResponse;
 import java.util.List;
 
@@ -11,4 +12,6 @@ public interface FindGroupService {
     List<GroupSummaryResponse> findMyGroups(Long memberId);
 
     GroupDetailsResponse findOne(Long groupId, Long memberId);
+
+    GroupNameResponse findName(Long groupId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/findGroup/FindGroupServiceImpl.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/findGroup/FindGroupServiceImpl.java
@@ -4,8 +4,10 @@ import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
 import foot.footprint.domain.group.dto.find.GroupDetailsDto;
 import foot.footprint.domain.group.dto.find.GroupDetailsResponse;
+import foot.footprint.domain.group.dto.find.GroupNameResponse;
 import foot.footprint.domain.group.dto.find.GroupSummaryResponse;
 import foot.footprint.global.error.exception.NotAuthorizedOrExistException;
+import foot.footprint.global.error.exception.NotExistsException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class FindGroupServiceImpl implements FindGroupService{
+public class FindGroupServiceImpl implements FindGroupService {
 
     private final MemberGroupRepository memberGroupRepository;
 
@@ -37,5 +39,13 @@ public class FindGroupServiceImpl implements FindGroupService{
         GroupDetailsDto response = groupRepository.findGroupDetails(groupId, memberId)
             .orElseThrow(() -> new NotAuthorizedOrExistException("그룹을 조회할 권한이 없습니다."));
         return GroupDetailsResponse.toResponse(memberId, response);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupNameResponse findName(Long groupId, Long memberId) {
+        String groupName = groupRepository.findGroupName(memberId, groupId)
+            .orElseThrow(() -> new NotExistsException("그룹에 속해있지 않거나 해당되는 그룹이 존재하지 않습니다."));
+        return new GroupNameResponse(groupName);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/secession/SecessionGroupServiceImpl.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/secession/SecessionGroupServiceImpl.java
@@ -1,5 +1,7 @@
 package foot.footprint.domain.group.application.secession;
 
+import foot.footprint.domain.article.dao.EditArticleRepository;
+import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
 import foot.footprint.domain.group.domain.Group;
@@ -21,6 +23,10 @@ public class SecessionGroupServiceImpl implements SecessionGroupService{
 
     private final MemberGroupRepository memberGroupRepository;
 
+    private final ArticleGroupRepository articleGroupRepository;
+
+    private final EditArticleRepository editArticleRepository;
+
     @Override
     @Transactional
     public void secessionGroup(Long groupId, Long memberId) {
@@ -29,6 +35,7 @@ public class SecessionGroupServiceImpl implements SecessionGroupService{
             checkRemainingMember(groupId, memberId);
             return;
         }
+        organizeArticle(groupId, memberId);
         deleteMemberGroup(groupId, memberId);
     }
 
@@ -41,6 +48,7 @@ public class SecessionGroupServiceImpl implements SecessionGroupService{
         List<MemberGroup> memberGroups = memberGroupRepository.findAllByGroupId(groupId);
         //owner 만 그룹에 남아있을 경우
         if (memberGroups.size() == 1) {
+            organizeArticle(groupId, memberId);
             groupRepository.deleteById(groupId);
             log.info(groupId + " 그룹이 삭제되었습니다.");
             return;
@@ -52,6 +60,7 @@ public class SecessionGroupServiceImpl implements SecessionGroupService{
         MemberGroup nextMemberGroup = findNextOwner(memberGroups, memberId);
         Long nextOwnerId = nextMemberGroup.getMember_id();
         groupRepository.updateOwner(groupId, nextOwnerId);
+        organizeArticle(groupId, memberId);
         deleteMemberGroup(groupId, memberId);
     }
 
@@ -66,5 +75,10 @@ public class SecessionGroupServiceImpl implements SecessionGroupService{
         if (deleted == 0) {
             throw new NotExistsException("이미 탈퇴한 그룹이거나 존재하지 않는 그룹입니다.");
         }
+    }
+
+    private void organizeArticle(Long groupId, Long memberId){
+        editArticleRepository.updatePrivateMapTrue(memberId, groupId);
+        articleGroupRepository.deleteArticleGroup(memberId, groupId);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/application/secession/SecessionGroupServiceImpl.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/application/secession/SecessionGroupServiceImpl.java
@@ -48,7 +48,7 @@ public class SecessionGroupServiceImpl implements SecessionGroupService{
         List<MemberGroup> memberGroups = memberGroupRepository.findAllByGroupId(groupId);
         //owner 만 그룹에 남아있을 경우
         if (memberGroups.size() == 1) {
-            organizeArticle(groupId, memberId);
+            editArticleRepository.updatePrivateMapTrue(memberId, groupId);
             groupRepository.deleteById(groupId);
             log.info(groupId + " 그룹이 삭제되었습니다.");
             return;

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/ArticleGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/ArticleGroupRepository.java
@@ -3,11 +3,17 @@ package foot.footprint.domain.group.dao;
 import foot.footprint.domain.group.domain.ArticleGroup;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface ArticleGroupRepository {
 
     int saveArticleGroupList(List<ArticleGroup> articleGroups);
 
+    int deleteArticleGroup(Long memberId, Long groupId);
+
     boolean existsArticleInMyGroup(Long articleId, Long memberId);
+
+    @Select("select * from Article_group order by id")
+    List<ArticleGroup> findAll();
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dao/MemberGroupRepository.java
@@ -32,4 +32,6 @@ public interface MemberGroupRepository {
 
     @Select("SELECT * FROM member_group WHERE group_id = #{groupId} ORDER BY id")
     List<MemberGroup> findAllByGroupId(Long groupId);
+
+    boolean existsMemberInGroup(Long memberId, Long groupId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/group/dto/find/GroupNameResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/group/dto/find/GroupNameResponse.java
@@ -1,0 +1,13 @@
+package foot.footprint.domain.group.dto.find;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupNameResponse {
+
+    private String name;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/application/auth/LoginService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/application/auth/LoginService.java
@@ -30,7 +30,7 @@ public class LoginService implements AuthService{
     public String process(AuthRequest authRequest) {
         LoginRequest loginRequest = (LoginRequest) authRequest;
         Member member = findMember(loginRequest);
-//        verifyPassword(loginRequest, member);
+        verifyPassword(loginRequest, member);
         return tokenProvider.createAccessToken(String.valueOf(member.getId()), Role.USER);
     }
 

--- a/backend/footprint/src/main/resources/mapper/article/EditArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/EditArticleMapper.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="foot.footprint.domain.article.dao.EditArticleRepository">
+  <update id="updatePrivateMapTrue">
+    UPDATE article SET private_map = true
+    WHERE id in (SELECT a.id FROM article a join article_group g ON a.id = g.article_id
+    WHERE a.member_id = #{memberId} AND g.group_id = #{groupId})
+  </update>
+</mapper>

--- a/backend/footprint/src/main/resources/mapper/group/ArticleGroupMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/group/ArticleGroupMapper.xml
@@ -15,4 +15,13 @@
     where a.article_id = #{articleId} and m.member_id = #{memberId}
     )
   </select>
+  <delete id="deleteArticleGroup">
+    DELETE FROM article_group
+    WHERE id in (SELECT g.id FROM article a join article_group g ON a.id = g.article_id
+    WHERE a.member_id = #{memberId} AND g.group_id = #{groupId})
+  </delete>
+  <update id="changeGroupName">
+    UPDATE group_table SET name = #{newName}
+    WHERE id = #{groupId} and owner_id =#{ownerId}
+  </update>
 </mapper>

--- a/backend/footprint/src/main/resources/mapper/group/MemberGroupMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/group/MemberGroupMapper.xml
@@ -27,4 +27,8 @@
     FROM group_table g LEFT JOIN member_group m ON (g.id = m.group_id)
     WHERE m.member_id = #{memberId}
   </select>
+  <select id="existsMemberInGroup" resultType="boolean">
+    SELECT EXISTS (
+    SELECT 1 FROM member_group where group_id = #{groupId} and member_id = #{memberId} )
+  </select>
 </mapper>

--- a/backend/footprint/src/test/java/foot/footprint/bulkInsert/CreateBulkArticleTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/bulkInsert/CreateBulkArticleTest.java
@@ -4,12 +4,8 @@ import foot.footprint.domain.article.dao.CreateArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.domain.group.dao.GroupRepository;
-import foot.footprint.domain.group.domain.ArticleGroup;
-import foot.footprint.domain.group.domain.Group;
 import foot.footprint.domain.member.dao.MemberRepository;
-import foot.footprint.domain.member.domain.AuthProvider;
 import foot.footprint.domain.member.domain.Member;
-import foot.footprint.domain.member.domain.Role;
 import foot.footprint.featureFactory.ArticleFeatureFactory;
 import foot.footprint.featureFactory.MemberFeatureFactory;
 import org.jeasy.random.EasyRandom;
@@ -18,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.StopWatch;
 
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -39,11 +34,11 @@ public class CreateBulkArticleTest {
 
     @Autowired
     private ArticleGroupRepository articleGroupRepository;
-    @Test
+//    @Test
     public void create() {
         //given
         EasyRandom memberEasyRandom = MemberFeatureFactory.create();
-        Member member = buildMember();
+        Member member = memberEasyRandom.nextObject(Member.class);
         memberRepository.saveMember(member);
         EasyRandom articleEasyRandom = ArticleFeatureFactory.create(member.getId());
 
@@ -71,53 +66,5 @@ public class CreateBulkArticleTest {
         assertThat(result).isEqualTo(articles.size());
         assertThat(articles.get(3330).getId()).isNotNull();
         assertThat(articles.get(3330).getMember_id()).isEqualTo(member.getId());
-
-        //when -그룹 추가
-        Group group = buildGroup(member.getId());
-        groupRepository.saveGroup(group);
-        var stopWatch2 = new StopWatch();
-        stopWatch2.start();
-        List<ArticleGroup> articleGroups = articles.stream()
-                .parallel()
-                .map(article -> ArticleGroup.createArticleGroup(group.getId(), article.getId()))
-                .collect(Collectors.toList());
-        stopWatch2.stop();
-        System.out.println("객체 생성시간: " + stopWatch2.getTotalTimeSeconds());
-
-        var queryStopWatch2 = new StopWatch();
-        queryStopWatch2.start();
-        int result2 = 0;
-        for (int i = 0; i < articleGroups.size(); i += 1000) {
-            List<ArticleGroup> articleGroups1 = articleGroups.subList(i, i + 1000);
-            result2 += articleGroupRepository.saveArticleGroupList(articleGroups1);
-        }
-        queryStopWatch2.stop();
-        System.out.println("DB 삽입시간: " + (queryStopWatch2.getTotalTimeSeconds()));
-
-        //then
-        assertThat(result2).isEqualTo(articles.size());
-        assertThat(articles.get(3330).getId()).isNotNull();
-        assertThat(articles.get(3330).getMember_id()).isEqualTo(member.getId());
-    }
-
-    private Member buildMember() {
-        return Member.builder()
-                .nick_name("nickName")
-                .email("email@naver.com")
-                .provider(AuthProvider.local)
-                .password("password")
-                .provider_id(null)
-                .image_url(null)
-                .join_date(new Date())
-                .role(Role.USER)
-                .build();
-    }
-
-    private Group buildGroup(Long ownerId) {
-        return Group.builder()
-                .create_date(new Date())
-                .name("test_group")
-                .invitation_code("testCode")
-                .owner_id(ownerId).build();
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
@@ -41,7 +41,7 @@ public class RepositoryTest {
             .latitude(10.0)
             .longitude(10.0)
             .public_map(true)
-            .private_map(true)
+            .private_map(false)
             .title("test")
             .create_date(new Date())
             .member_id(memberId).build();

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/EditArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/EditArticleRepositoryTest.java
@@ -85,10 +85,11 @@ public class EditArticleRepositoryTest extends RepositoryTest {
         articleGroupRepository.saveArticleGroupList(articleGroups);
 
         //when
-        editArticleRepository.updatePrivateMapTrue(member1.getId(), group.getId());
+        int result = editArticleRepository.updatePrivateMapTrue(member1.getId(), group.getId());
         List<Article> updatedArticles = findArticleRepository.findAll();
 
         //then
+        assertThat(result).isEqualTo(2);
         assertThat(updatedArticles.get(0).isPrivate_map()).isTrue();
         assertThat(updatedArticles.get(1).isPrivate_map()).isTrue();
         assertThat(updatedArticles.get(2).isPrivate_map()).isFalse();

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/EditArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/EditArticleRepositoryTest.java
@@ -6,12 +6,21 @@ import foot.footprint.domain.article.dao.CreateArticleRepository;
 import foot.footprint.domain.article.dao.EditArticleRepository;
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
+import foot.footprint.domain.group.dao.ArticleGroupRepository;
+import foot.footprint.domain.group.dao.GroupRepository;
+import foot.footprint.domain.group.dao.MemberGroupRepository;
+import foot.footprint.domain.group.domain.ArticleGroup;
+import foot.footprint.domain.group.domain.Group;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.AuthProvider;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.domain.member.domain.Role;
+import foot.footprint.featureFactory.MemberFeatureFactory;
 import foot.footprint.repository.RepositoryTest;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,6 +38,15 @@ public class EditArticleRepositoryTest extends RepositoryTest {
     @Autowired
     private FindArticleRepository findArticleRepository;
 
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private MemberGroupRepository memberGroupRepository;
+
+    @Autowired
+    private ArticleGroupRepository articleGroupRepository;
+
     @Test
     public void editArticle() {
         //given
@@ -44,6 +62,36 @@ public class EditArticleRepositoryTest extends RepositoryTest {
             .isEqualTo(1);
         assertThat(findArticleRepository.findById(article.getId()).get().getContent())
             .isEqualTo(newContent);
+    }
+
+    @Test
+    public void updatePrivateMapTrue() {
+        //given
+        EasyRandom memberEasyRandom = MemberFeatureFactory.create();
+        Member member1 = memberEasyRandom.nextObject(Member.class);
+        memberRepository.saveMember(member1);
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(buildArticle(member1.getId()));
+        articles.add(buildArticle(member1.getId()));
+        articles.add(buildArticle(member1.getId()));
+        createArticleRepository.saveArticleList(articles);
+        Group group = buildGroup(member1.getId());
+        groupRepository.saveGroup(group);
+        memberGroupRepository.saveMemberGroup(buildMemberGroup(group.getId(), member1.getId()));
+        List<ArticleGroup> articleGroups = new ArrayList<>();
+        articleGroups.add(ArticleGroup.createArticleGroup(group.getId(), articles.get(0).getId()));
+        articleGroups.add(ArticleGroup.createArticleGroup(group.getId(), articles.get(1).getId()));
+        articleGroupRepository.saveArticleGroupList(articleGroups);
+
+        //when
+        editArticleRepository.updatePrivateMapTrue(member1.getId(), group.getId());
+        List<Article> updatedArticles = findArticleRepository.findAll();
+
+        //then
+        assertThat(updatedArticles.get(0).isPrivate_map()).isTrue();
+        assertThat(updatedArticles.get(1).isPrivate_map()).isTrue();
+        assertThat(updatedArticles.get(2).isPrivate_map()).isFalse();
     }
 
     private Article setUp(Long memberId) {

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/ArticleGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/ArticleGroupRepositoryTest.java
@@ -84,6 +84,31 @@ public class ArticleGroupRepositoryTest extends RepositoryTest {
 
     }
 
+    @Test
+    public void deleteArticleGroup(){
+        //given
+        Member member1 = buildMember();
+        memberRepository.saveMember(member1);
+        Article article2 = buildArticle(member1.getId());
+        List<Article> articles = new ArrayList<>();
+        articles.add(article);
+        articles.add(article2);
+        createArticleRepository.saveArticleList(articles);
+        List<ArticleGroup> articleGroups = new ArrayList<>();
+        articleGroups.add(buildArticleGroup(group.getId(), article.getId()));
+        articleGroups.add(buildArticleGroup(group.getId(), article2.getId()));
+        articleGroupRepository.saveArticleGroupList(articleGroups);
+
+        //when
+        int result = articleGroupRepository.deleteArticleGroup(member.getId(), group.getId());
+        List<ArticleGroup> deletedArticleGroups = articleGroupRepository.findAll();
+
+        //then
+        assertThat(result).isEqualTo(1);
+        assertThat(deletedArticleGroups).hasSize(1);
+        assertThat(deletedArticleGroups.get(0).getArticle_id()).isEqualTo(article2.getId());
+    }
+
     private ArticleGroup buildArticleGroup(Long groupId, Long articleId) {
         return ArticleGroup.createArticleGroup(groupId, articleId);
     }

--- a/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/group/MeemberGroupRepositoryTest.java
@@ -169,4 +169,25 @@ public class MeemberGroupRepositoryTest extends RepositoryTest {
         //then
         assertThat(responses).hasSize(1);
     }
+
+    @Test
+    public void existsMemberInGroup() {
+        //given
+        Member member = buildMember();
+        memberRepository.saveMember(member);
+        Group group1 = buildGroup(member.getId());
+        groupRepository.saveGroup(group1);
+        MemberGroup memberGroup1 = buildMemberGroup(group1.getId(), member.getId());
+        memberGroupRepository.saveMemberGroup(memberGroup1);
+
+        //when
+        boolean result1 = memberGroupRepository.existsMemberInGroup(member.getId(), group1.getId());
+        boolean result2 = memberGroupRepository.existsMemberInGroup(member.getId(), 300L);
+        boolean result3 = memberGroupRepository.existsMemberInGroup(240L, group1.getId());
+
+        //then
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
+        assertThat(result3).isFalse();
+    }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/group/DeportMemberServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/DeportMemberServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import foot.footprint.domain.article.dao.EditArticleRepository;
 import foot.footprint.domain.article.exception.NotMatchMemberException;
 import foot.footprint.domain.group.application.deportMember.DeportMemberServiceImpl;
+import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
 import foot.footprint.domain.group.domain.Group;
@@ -27,6 +29,12 @@ public class DeportMemberServiceTest {
 
     @Mock
     private GroupRepository groupRepository;
+
+    @Mock
+    private EditArticleRepository editArticleRepository;
+
+    @Mock
+    private ArticleGroupRepository articleGroupRepository;
 
     @InjectMocks
     private DeportMemberServiceImpl deportMemberServiceImpl;

--- a/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/group/SecessionGroupServiceTest.java
@@ -5,7 +5,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import foot.footprint.domain.article.dao.EditArticleRepository;
 import foot.footprint.domain.group.application.secession.SecessionGroupServiceImpl;
+import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.domain.group.dao.GroupRepository;
 import foot.footprint.domain.group.dao.MemberGroupRepository;
 import foot.footprint.domain.group.domain.Group;
@@ -29,6 +31,12 @@ public class SecessionGroupServiceTest {
     @Spy
     private MemberGroupRepository memberGroupRepository;
 
+    @Spy
+    private ArticleGroupRepository articleGroupRepository;
+
+    @Spy
+    private EditArticleRepository editArticleRepository;
+
     @InjectMocks
     private SecessionGroupServiceImpl secessionGroupServiceImpl;
 
@@ -48,6 +56,8 @@ public class SecessionGroupServiceTest {
 
         //then
         verify(memberGroupRepository, times(0)).findAllByGroupId(any());
+        verify(articleGroupRepository, times(1)).deleteArticleGroup(any(), any());
+        verify(editArticleRepository, times(1)).updatePrivateMapTrue(any(), any());
     }
 
     @Test

--- a/frontend/footprint/src/components/articleDetail/ArticleDetailPage.js
+++ b/frontend/footprint/src/components/articleDetail/ArticleDetailPage.js
@@ -67,7 +67,8 @@ const ArticleDetailPage = (props) => {
       props.history.push("/");
     }
   }, [articleId, mapType]);
-
+console.log(groupId)
+console.log("dddddddddddddddddd")
   return (
     <Outside>
       <ChangeContentModal

--- a/frontend/footprint/src/components/home/DefaultMapPage.js
+++ b/frontend/footprint/src/components/home/DefaultMapPage.js
@@ -122,6 +122,11 @@ const DefaultMapPage = (props) => {
       ).then((mapArticlesPromise) => {
         setArticles(mapArticlesPromise);
       });
+      findGroupNameApi({
+        groupId: groupId,
+        accessToken: accessToken,
+        history: props.history
+      }).then(groupPromise => setGroupName(groupPromise.name))
     }
   }, [zoom, center, mapType, groupId, myLocation]);
 


### PR DESCRIPTION
resolved: #84 

프론트 부분을 구현하면서 백엔드와 서로 안맞거나 잘못 구현된 부분들을 발견하였다. 그 중 그룹관련 부분이 많았으며 이들을 수정하려고 한다. 문제들은 아래와 같다.

1. 그룹 탈퇴시 탈퇴한 맴버가 작성한 게시글에 마이페이지를 통해 접근 가능
2. 그룹이 완전히 삭제될 시 articleGroup에 있는 article 정리
3. 그룹 지도 글 리스트 조회와 별개로 그룹 이름 찾는 메서드 구현
4. 그룹 지도 게시글 리스트 조회 시 accessToken으로 들어온 memberId가 그룹에 속한 것인지 확인하는 로직 추가