### PR TITLE
Refactor#12

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindArticleDetailsServiceImpl.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindArticleDetailsServiceImpl.java
@@ -2,12 +2,10 @@ package foot.footprint.domain.article.application.findArticleDetails;
 
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
-import foot.footprint.domain.article.dto.ArticleDetailsDto;
+import foot.footprint.domain.article.dto.ArticlePageDto;
 import foot.footprint.domain.article.dto.ArticlePageResponse;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
-import foot.footprint.domain.articleLike.dto.ArticleLikeDto;
 import foot.footprint.domain.comment.dao.FindCommentRepository;
-import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
 import foot.footprint.global.error.exception.NotAuthorizedOrExistException;
 import foot.footprint.global.error.exception.NotExistsException;
@@ -32,20 +30,18 @@ public abstract class FindArticleDetailsServiceImpl implements FindArticleDetail
     }
 
     protected void addNonLoginInfo(Long articleId, ArticlePageResponse response) {
-        ArticleDetailsDto details = findArticleRepository.findArticleDetails(articleId);
-        List<CommentResponse> comments = findCommentRepository.findAllByArticleId(articleId);
-        response.addNonLoginInfo(details, comments);
+        // 추가 예정
     }
 
-    protected void addLoginInfo(Long articleId, Long memberId,
-        ArticlePageResponse response) {
-        boolean myArticleLikeExists = articleLikeRepository.existsMyLike(
-            new ArticleLikeDto(articleId, memberId));
+    protected void addLoginInfo(Long articleId, Long memberId, ArticlePageResponse response) {
+        ArticlePageDto articlePageDto = findArticleRepository.findArticleDetails(articleId,
+            memberId).orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
         List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(articleId, memberId);
-        response.addLoginInfo(myArticleLikeExists, commentLikes, memberId);
+        response.addNonLoginInfo(articlePageDto.getArticleDetails(), articlePageDto.getComments());
+        response.addLoginInfo(articlePageDto.isArticleLike(), commentLikes, memberId);
     }
 
-    protected void validateMember(CustomUserDetails userDetails){
+    protected void validateMember(CustomUserDetails userDetails) {
         if (userDetails == null) {
             throw new NotAuthorizedOrExistException("해당 글에 접근할 권한이 없습니다.");
         }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindArticleDetailsServiceImpl.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindArticleDetailsServiceImpl.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.application.findArticleDetails;
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.dto.ArticlePageDto;
+import foot.footprint.domain.article.dto.ArticlePageIfNonLoginDto;
 import foot.footprint.domain.article.dto.ArticlePageResponse;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.comment.dao.FindCommentRepository;
@@ -30,15 +31,17 @@ public abstract class FindArticleDetailsServiceImpl implements FindArticleDetail
     }
 
     protected void addNonLoginInfo(Long articleId, ArticlePageResponse response) {
-        // 추가 예정
+        ArticlePageIfNonLoginDto dto = findArticleRepository.findArticleDetailsIfNonLogin(articleId)
+            .orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
+        response.addNonLoginInfo(dto.getArticleDetails(), dto.getComments());
     }
 
     protected void addLoginInfo(Long articleId, Long memberId, ArticlePageResponse response) {
-        ArticlePageDto articlePageDto = findArticleRepository.findArticleDetails(articleId,
-            memberId).orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
+        ArticlePageDto dto = findArticleRepository.findArticleDetails(articleId, memberId)
+            .orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
         List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(articleId, memberId);
-        response.addNonLoginInfo(articlePageDto.getArticleDetails(), articlePageDto.getComments());
-        response.addLoginInfo(articlePageDto.isArticleLike(), commentLikes, memberId);
+        response.addNonLoginInfo(dto.getArticleDetails(), dto.getComments());
+        response.addLoginInfo(dto.isArticleLike(), commentLikes, memberId);
     }
 
     protected void validateMember(CustomUserDetails userDetails) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindGroupedArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindGroupedArticleDetails.java
@@ -34,7 +34,6 @@ public class FindGroupedArticleDetails extends FindArticleDetailsServiceImpl {
         ArticlePageResponse response = new ArticlePageResponse();
         validateMember(userDetails);
         ValidateIsMine.validateInMyGroup(articleId, userDetails.getId(), articleGroupRepository);
-        addNonLoginInfo(articleId, response);
         addLoginInfo(articleId, userDetails.getId(), response);
         return response;
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPrivateArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPrivateArticleDetails.java
@@ -35,7 +35,6 @@ public class FindPrivateArticleDetails extends FindArticleDetailsServiceImpl{
         ArticlePageResponse response = new ArticlePageResponse();
         validateMember(userDetails);
         ValidateIsMine.validateArticleIsMine(article.getMember_id(), userDetails.getId());
-        addNonLoginInfo(article.getId(), response);
         addLoginInfo(article.getId(), userDetails.getId(), response);
         return response;
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPrivateArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPrivateArticleDetails.java
@@ -6,6 +6,7 @@ import foot.footprint.domain.article.dto.ArticlePageResponse;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.comment.dao.FindCommentRepository;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import foot.footprint.global.security.user.CustomUserDetails;
 import foot.footprint.global.util.ValidateIsMine;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -30,7 +31,7 @@ public class FindPrivateArticleDetails extends FindArticleDetailsServiceImpl{
     public ArticlePageResponse findDetails(Long articleId, CustomUserDetails userDetails) {
         Article article = findAndValidateArticle(articleId);
         if (!article.isPrivate_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         ArticlePageResponse response = new ArticlePageResponse();
         validateMember(userDetails);

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPublicArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPublicArticleDetails.java
@@ -6,6 +6,7 @@ import foot.footprint.domain.article.dto.ArticlePageResponse;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.comment.dao.FindCommentRepository;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import foot.footprint.global.security.user.CustomUserDetails;
 import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -30,11 +31,11 @@ public class FindPublicArticleDetails extends FindArticleDetailsServiceImpl{
     public ArticlePageResponse findDetails(Long articleId, CustomUserDetails userDetails) {
         Article article = findAndValidateArticle(articleId);
         if (!article.isPublic_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         ArticlePageResponse response = new ArticlePageResponse();
-        addNonLoginInfo(articleId, response);
         if (userDetails == null) {
+            addNonLoginInfo(articleId, response);
             response.addLoginInfo(false, new ArrayList<>(), -1L);
             return response;
         }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -2,7 +2,7 @@ package foot.footprint.domain.article.dao;
 
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.domain.LocationRange;
-import foot.footprint.domain.article.dto.ArticleDetailsDto;
+import foot.footprint.domain.article.dto.ArticlePageDto;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
@@ -23,5 +23,5 @@ public interface FindArticleRepository {
     @Select("Select * from article where id=#{articleId}")
     Optional<Article> findById(Long articleId);
 
-    ArticleDetailsDto findArticleDetails(Long articleId);
+    ArticlePageDto findArticleDetails(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.dao;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.domain.LocationRange;
 import foot.footprint.domain.article.dto.ArticlePageDto;
+import foot.footprint.domain.article.dto.ArticlePageIfNonLoginDto;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
@@ -24,4 +25,6 @@ public interface FindArticleRepository {
     Optional<Article> findById(Long articleId);
 
     Optional<ArticlePageDto> findArticleDetails(Long articleId, Long memberId);
+
+    Optional<ArticlePageIfNonLoginDto> findArticleDetailsIfNonLogin(Long articleId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -23,5 +23,5 @@ public interface FindArticleRepository {
     @Select("Select * from article where id=#{articleId}")
     Optional<Article> findById(Long articleId);
 
-    ArticlePageDto findArticleDetails(Long articleId, Long memberId);
+    Optional<ArticlePageDto> findArticleDetails(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetails.java
@@ -1,0 +1,36 @@
+package foot.footprint.domain.article.dto;
+
+import foot.footprint.global.domain.AuthorDto;
+import java.util.Date;
+import lombok.Getter;
+
+@Getter
+public class ArticleDetails {
+
+    private Long id;
+    private String title;
+    private String content;
+    private Double latitude;
+    private Double longitude;
+    private AuthorDto author;
+    private Date createDate;
+    private Long totalLikes;
+
+    public ArticleDetails(Long id, String title, String content, Double latitude, Double longitude,
+        Long userId, String nickName, String imageUrl, Date createDate, Long totalLikes) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.author = new AuthorDto(userId, nickName, imageUrl);
+        this.createDate = createDate;
+        this.totalLikes = totalLikes;
+    }
+
+    public static ArticleDetails toArticleDetails(ArticleDetailsDto dto) {
+        return new ArticleDetails(dto.getId(), dto.getTitle(), dto.getContent(), dto.getLatitude(),
+            dto.getLongitude(), dto.getWriterId(), dto.getWriterName(), dto.getWriterImageUrl(),
+            dto.getCreateDate(), dto.getTotalLikes());
+    }
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetailsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticleDetailsDto.java
@@ -1,10 +1,13 @@
 package foot.footprint.domain.article.dto;
 
-import foot.footprint.global.domain.AuthorDto;
 import java.util.Date;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ArticleDetailsDto {
 
     private Long id;
@@ -12,20 +15,9 @@ public class ArticleDetailsDto {
     private String content;
     private Double latitude;
     private Double longitude;
-    private AuthorDto author;
+    private Long writerId;
+    private String writerName;
+    private String writerImageUrl;
     private Date createDate;
     private Long totalLikes;
-
-    public ArticleDetailsDto(Long id, String title, String content, Double latitude,
-        Double longitude,
-        Long userId, String nickName, String imageUrl, Date createDate, Long totalLikes) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.author = new AuthorDto(userId, nickName, imageUrl);
-        this.createDate = createDate;
-        this.totalLikes = totalLikes;
-    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageDto.java
@@ -1,0 +1,17 @@
+package foot.footprint.domain.article.dto;
+
+import foot.footprint.domain.comment.dto.CommentsDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArticlePageDto {
+    private Long articleId;
+    private ArticleDetailsDto articleDetails;
+    private boolean articleLike;
+    private List<CommentsDto> comments;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageIfNonLoginDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageIfNonLoginDto.java
@@ -1,0 +1,16 @@
+package foot.footprint.domain.article.dto;
+
+import foot.footprint.domain.comment.dto.CommentsDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArticlePageIfNonLoginDto {
+    private Long articleId;
+    private ArticleDetailsDto articleDetails;
+    private List<CommentsDto> comments;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public class ArticlePageResponse {
 
-    private ArticleDetailsDto articleDetails;
+    private ArticleDetails articleDetails;
     private boolean articleLike;
     private List<CommentResponse> comments;
     private List<Long> commentLikes;
@@ -17,7 +17,7 @@ public class ArticlePageResponse {
 
     public ArticlePageResponse(ArticleDetailsDto articleDetails, boolean articleLike,
         List<CommentResponse> comments, List<Long> commentLikes, Long myMemberId) {
-        this.articleDetails = articleDetails;
+        this.articleDetails = ArticleDetails.toArticleDetails(articleDetails);
         this.articleLike = articleLike;
         this.comments = comments;
         this.commentLikes = commentLikes;
@@ -28,7 +28,7 @@ public class ArticlePageResponse {
     }
 
     public void addNonLoginInfo(ArticleDetailsDto articleDetails, List<CommentsDto> comments) {
-        this.articleDetails = articleDetails;
+        this.articleDetails = ArticleDetails.toArticleDetails(articleDetails);
         this.comments = comments.stream().map(CommentResponse::toCommentResponse)
             .collect(Collectors.toList());
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
@@ -1,6 +1,7 @@
 package foot.footprint.domain.article.dto;
 
 import foot.footprint.domain.comment.dto.CommentResponse;
+import foot.footprint.domain.comment.dto.CommentsDto;
 import java.util.List;
 import lombok.Getter;
 
@@ -9,12 +10,12 @@ public class ArticlePageResponse {
 
     private ArticleDetailsDto articleDetails;
     private boolean articleLike;
-    private List<CommentResponse> comments;
+    private List<CommentsDto> comments;
     private List<Long> commentLikes;
     private Long myMemberId;
 
     public ArticlePageResponse(ArticleDetailsDto articleDetails, boolean articleLike,
-        List<CommentResponse> comments, List<Long> commentLikes, Long myMemberId) {
+        List<CommentsDto> comments, List<Long> commentLikes, Long myMemberId) {
         this.articleDetails = articleDetails;
         this.articleLike = articleLike;
         this.comments = comments;
@@ -25,7 +26,7 @@ public class ArticlePageResponse {
     public ArticlePageResponse() {
     }
 
-    public void addNonLoginInfo(ArticleDetailsDto articleDetails, List<CommentResponse> comments) {
+    public void addNonLoginInfo(ArticleDetailsDto articleDetails, List<CommentsDto> comments) {
         this.articleDetails = articleDetails;
         this.comments = comments;
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/ArticlePageResponse.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.dto;
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentsDto;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -10,12 +11,12 @@ public class ArticlePageResponse {
 
     private ArticleDetailsDto articleDetails;
     private boolean articleLike;
-    private List<CommentsDto> comments;
+    private List<CommentResponse> comments;
     private List<Long> commentLikes;
     private Long myMemberId;
 
     public ArticlePageResponse(ArticleDetailsDto articleDetails, boolean articleLike,
-        List<CommentsDto> comments, List<Long> commentLikes, Long myMemberId) {
+        List<CommentResponse> comments, List<Long> commentLikes, Long myMemberId) {
         this.articleDetails = articleDetails;
         this.articleLike = articleLike;
         this.comments = comments;
@@ -28,7 +29,8 @@ public class ArticlePageResponse {
 
     public void addNonLoginInfo(ArticleDetailsDto articleDetails, List<CommentsDto> comments) {
         this.articleDetails = articleDetails;
-        this.comments = comments;
+        this.comments = comments.stream().map(CommentResponse::toCommentResponse)
+            .collect(Collectors.toList());
     }
 
     public void addLoginInfo(boolean articleLike, List<Long> commentLikes, Long myMemberId) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/ChangePrivateArticleLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/ChangePrivateArticleLikeService.java
@@ -4,6 +4,7 @@ import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.articleLike.dto.ArticleLikeDto;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import foot.footprint.global.util.ValidateIsMine;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,7 @@ public class ChangePrivateArticleLikeService extends ChangeArticleLikeServiceImp
     public void changeArticleLike(ArticleLikeDto articleLikeDto) {
         Article article = findAndValidateArticle(articleLikeDto.getArticleId());
         if (!article.isPrivate_map()) {
-            throw new NumberFormatException("게시글이 개인지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 개인지도에 포함되지 않습니다.");
         }
         ValidateIsMine.validateArticleIsMine(article.getMember_id(), articleLikeDto.getMemberId());
         changeLike(articleLikeDto);

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/ChangePublicArticleLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/ChangePublicArticleLikeService.java
@@ -4,6 +4,7 @@ import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.articleLike.dto.ArticleLikeDto;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class ChangePublicArticleLikeService extends ChangeArticleLikeServiceImpl
     public void changeArticleLike(ArticleLikeDto articleLikeDto) {
         Article article = findAndValidateArticle(articleLikeDto.getArticleId());
         if (!article.isPublic_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         changeLike(articleLikeDto);
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPrivateArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPrivateArticle.java
@@ -7,6 +7,7 @@ import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.global.domain.AuthorDto;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import foot.footprint.global.util.ValidateIsMine;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class CreateCommentOnPrivateArticle extends CreateCommentServiceImpl {
     public CommentResponse createComment(Long articleId, String content, Long memberId) {
         Article article = findAndValidateArticle(articleId);
         if (!article.isPrivate_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         Member member = findAndValidateMember(memberId);
         AuthorDto authorDto = AuthorDto.buildAuthorDto(member);

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPublicArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPublicArticle.java
@@ -7,6 +7,7 @@ import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.global.domain.AuthorDto;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +28,7 @@ public class CreateCommentOnPublicArticle extends CreateCommentServiceImpl {
     public CommentResponse createComment(Long articleId, String content, Long memberId) {
         Article article = findAndValidateArticle(articleId);
         if (!article.isPublic_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         Member member = findAndValidateMember(memberId);
         return saveComment(articleId, content, AuthorDto.buildAuthorDto(member));

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
@@ -14,11 +14,12 @@ public class CommentResponse {
     private Date createDate;
     private Long totalLikes;
 
-    public CommentResponse(Long id, String content, AuthorDto author, Date createDate) {
+    public CommentResponse(Long id, String content, AuthorDto author, Date createDate, Long totalLikes) {
         this.id = id;
         this.content = content;
         this.author = author;
         this.createDate = createDate;
+        this.totalLikes = totalLikes;
     }
 
     public CommentResponse(Long id, String content, Long userId, String nickName, String imageUrl,
@@ -35,7 +36,8 @@ public class CommentResponse {
             comment.getId(),
             comment.getContent(),
             authorDto,
-            comment.getCreate_date()
+            comment.getCreate_date(),
+            0L
         );
     }
 
@@ -45,7 +47,8 @@ public class CommentResponse {
             commentsDto.getCommentContent(),
             new AuthorDto(
                 commentsDto.getMemberId(), commentsDto.getNickName(), commentsDto.getImageUrl()),
-            commentsDto.getCommentCreateDate()
+            commentsDto.getCommentCreateDate(),
+            commentsDto.getCommentTotalLikes()
         );
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
@@ -38,4 +38,14 @@ public class CommentResponse {
             comment.getCreate_date()
         );
     }
+
+    public static CommentResponse toCommentResponse(CommentsDto commentsDto) {
+        return new CommentResponse(
+            commentsDto.getCommentId(),
+            commentsDto.getCommentContent(),
+            new AuthorDto(
+                commentsDto.getMemberId(), commentsDto.getNickName(), commentsDto.getImageUrl()),
+            commentsDto.getCommentCreateDate()
+        );
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentsDto.java
@@ -1,0 +1,20 @@
+package foot.footprint.domain.comment.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentsDto {
+
+    private Long commentId;
+    private String commentContent;
+    private Long memberId;
+    private String nickName;
+    private String imageUrl;
+    private Date commentCreateDate;
+    private Long commentTotalLikes;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePrivateCommentLike.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePrivateCommentLike.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.commentLike.application;
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import foot.footprint.global.util.ValidateIsMine;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ public class ChangePrivateCommentLike extends ChangeCommentLikeServiceImpl {
     public void changeMyLike(Long commentId, Long articleId, Boolean hasILiked, Long memberId) {
         Article article = findAndValidateArticle(articleId);
         if (!article.isPrivate_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         ValidateIsMine.validateArticleIsMine(article.getMember_id(), memberId);
         changeLike(commentId, memberId, hasILiked);

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePublicCommentLike.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePublicCommentLike.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.commentLike.application;
 import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
+import foot.footprint.global.error.exception.WrongMapTypeException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +22,7 @@ public class ChangePublicCommentLike extends ChangeCommentLikeServiceImpl {
     public void changeMyLike(Long commentId, Long articleId, Boolean hasILiked, Long memberId) {
         Article article = findAndValidateArticle(articleId);
         if (!article.isPublic_map()) {
-            throw new NumberFormatException("게시글이 전체지도에 포함되지 않습니다.");
+            throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         changeLike(commentId, memberId, hasILiked);
     }

--- a/backend/footprint/src/main/resources/mapper/article/EditArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/EditArticleMapper.xml
@@ -3,8 +3,8 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="foot.footprint.domain.article.dao.EditArticleRepository">
   <update id="updatePrivateMapTrue">
-    UPDATE article SET private_map = true
-    WHERE id in (SELECT a.id FROM article a join article_group g ON a.id = g.article_id
-    WHERE a.member_id = #{memberId} AND g.group_id = #{groupId})
+    UPDATE article SET private_map = true WHERE id in
+    (SELECT id FROM (SELECT a.id as id FROM article a join article_group g ON a.id = g.article_id
+    WHERE a.member_id = #{memberId} AND g.group_id = #{groupId}) as at )
   </update>
 </mapper>

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -21,13 +21,16 @@
     longitude between #{locationRange.lowerLongitude} and #{locationRange.upperLongitude}
   </select>
   <select id="findArticleDetails" resultMap="ArticleDetails">
-    select a.id as articleId, a.id as id, a.title as title, a.content as content,
+    select a.id as articleId,
+    (SELECT EXISTS ( SELECT 1 FROM article_like
+    WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
+
+    a.id as id, a.title as title, a.content as content,
     a.latitude as latitude, a.longitude as longitude, a.member_id as writerId,
     m.nick_name as writerName, m.image_url as writerImageUrl, a.create_date as createDate,
     (SELECT count(l.id) FROM article a LEFT JOIN article_like l ON a.id = l.article_id
     WHERE a.id = #{articleId} GROUP BY a.id ) as totalLikes,
-    (SELECT EXISTS ( SELECT 1 FROM article_like
-    WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
+
     c.id as commentId, c.content as commentContent, c.member_id as memberId, cm.nick_name as nickName,
     cm.image_url as imageUrl, c.create_date as commentCreateDate, count(distinct cl.id) as commentTotalLikes
     FROM article a JOIN member m ON (a.member_id = m.id)
@@ -38,6 +41,7 @@
   </select>
   <resultMap id="ArticleDetails" type="ArticlePageDto">
     <id property="articleId" column="articleId"/>
+    <result property="articleLike" column="articleLike"/>
     <association property="articleDetails" javaType="ArticleDetailsDto">
       <id property="id" column="id"/>
       <result property="title" column="title"/>
@@ -50,7 +54,6 @@
       <result property="createDate" column="createDate"/>
       <result property="totalLikes" column="totalLikes"/>
     </association>
-    <association property="articleLike" javaType="boolean"/>
     <collection property="comments" notNullColumn="commentId"
       ofType="foot.footprint.domain.comment.dto.CommentsDto">
       <id property="commentId" column="commentId"/>

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -24,13 +24,11 @@
     select a.id as articleId,
     (SELECT EXISTS ( SELECT 1 FROM article_like
     WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
-
     a.id as id, a.title as title, a.content as content,
     a.latitude as latitude, a.longitude as longitude, a.member_id as writerId,
     m.nick_name as writerName, m.image_url as writerImageUrl, a.create_date as createDate,
     (SELECT count(l.id) FROM article a LEFT JOIN article_like l ON a.id = l.article_id
     WHERE a.id = #{articleId} GROUP BY a.id ) as totalLikes,
-
     c.id as commentId, c.content as commentContent, c.member_id as memberId, cm.nick_name as nickName,
     cm.image_url as imageUrl, c.create_date as commentCreateDate, count(distinct cl.id) as commentTotalLikes
     FROM article a JOIN member m ON (a.member_id = m.id)

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -1,31 +1,65 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="foot.footprint.domain.article.dao.FindArticleRepository">
-    <select id="findPublicArticles" resultType="Article">
-        select * from article use index(public_map_index) where public_map = true and
-        latitude between #{lowerLatitude} and #{upperLatitude} and
-        longitude between #{lowerLongitude} and #{upperLongitude}
-    </select>
-    <select id="findPrivateArticles" resultType="Article">
-        select * from article use index(private_map_index) where
-        member_id = #{memberId} and private_map = true and
-        latitude between #{locationRange.lowerLatitude} and #{locationRange.upperLatitude} and
-        longitude between #{locationRange.lowerLongitude} and #{locationRange.upperLongitude}
-    </select>
-    <select id="findArticlesByGroup" resultType="Article">
-        select a.* from article a
-        join article_group g on (a.id = g.article_id) where g.group_id = #{groupId}
-        and
-        latitude between #{locationRange.lowerLatitude} and #{locationRange.upperLatitude} and
-        longitude between #{locationRange.lowerLongitude} and #{locationRange.upperLongitude}
-    </select>
-    <select id="findArticleDetails" resultType="ArticleDetailsDto">
-        select distinct a.id, a.title, a.content, a.latitude, a.longitude, a.member_id, m.nick_name,
-        m.image_url, a.create_date, count(l.id)
-        from article a join member m on a.member_id = m.id
-        left join article_like l on a.id = l.article_id
-        where a.id = #{articleId}
-        group by a.id
-    </select>
+  <select id="findPublicArticles" resultType="Article">
+    select * from article use index(public_map_index) where public_map = true and
+    latitude between #{lowerLatitude} and #{upperLatitude} and
+    longitude between #{lowerLongitude} and #{upperLongitude}
+  </select>
+  <select id="findPrivateArticles" resultType="Article">
+    select * from article use index(private_map_index) where
+    member_id = #{memberId} and private_map = true and
+    latitude between #{locationRange.lowerLatitude} and #{locationRange.upperLatitude} and
+    longitude between #{locationRange.lowerLongitude} and #{locationRange.upperLongitude}
+  </select>
+  <select id="findArticlesByGroup" resultType="Article">
+    select a.* from article a
+    join article_group g on (a.id = g.article_id) where g.group_id = #{groupId}
+    and
+    latitude between #{locationRange.lowerLatitude} and #{locationRange.upperLatitude} and
+    longitude between #{locationRange.lowerLongitude} and #{locationRange.upperLongitude}
+  </select>
+  <select id="findArticleDetails" resultMap="ArticleDetails">
+    select distinct a.id as articleId, a.id as id, a.title as title, a.content as content,
+    a.latitude as latitude, a.longitude as longitude, a.member_id as writerId,
+    m.nick_name as writerName, m.image_url as writerImageUrl, a.create_date as createDate,
+    (SELECT count(l.id) FROM article a LEFT JOIN article_like l ON a.id = l.article_id
+    WHERE a.id = #{articleId} GROUP BY a.id ) as totalLikes,
+    (SELECT EXISTS ( SELECT 1 FROM article_like
+    WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
+    c.id as commentId, c.content as commentContent, c.member_id as memberId, cm.nick_name as nickName,
+    cm.image_url as imageUrl, c.create_date as commentCreateDate, count(cl.id) as commentTotalLikes,
+    FROM article a JOIN member m ON a.member_id = m.id
+    LEFT JOIN comment c ON a.id = c.article_id LEFT JOIN comment_like cl ON c.id = cl.comment_id
+    JOIN member cm ON c.member_id = cm.id
+    WHERE a.id = #{articleId}
+    GROUP BY c.id
+  </select>
+  <resultMap id="ArticleDetails" type="ArticlePageDto">
+    <id property="articleId" column="articleId"/>
+    <association property="articleDetails" javaType="ArticleDetailsDto2">
+      <id property="id" column="id"/>
+      <result property="title" column="title"/>
+      <result property="content" column="content"/>
+      <result property="latitude" column="latitude"/>
+      <result property="longitude" column="longitude"/>
+      <result property="writerId" column="writerId"/>
+      <result property="writerName" column="writerName"/>
+      <result property="writerImageUrl" column="writerImageUrl"/>
+      <result property="createDate" column="createDate"/>
+      <result property="totalLikes" column="totalLikes"/>
+    </association>
+    <association property="articleLike" javaType="boolean"/>
+    <collection property="comments" notNullColumn="commentId"
+      ofType="foot.footprint.domain.comment.dto.CommentsDto">
+      <id property="commentId" column="commentId"/>
+      <result property="commentContent" column="commentContent"/>
+      <result property="memberId" column="memberId"/>
+      <result property="nickName" column="nickName"/>
+      <result property="imageUrl" column="imageUrl"/>
+      <result property="commentCreateDate" column="commentCreateDate"/>
+      <result property="commentTotalLikes" column="commentTotalLikes"/>
+    </collection>
+  </resultMap>
 </mapper>

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -21,7 +21,7 @@
     longitude between #{locationRange.lowerLongitude} and #{locationRange.upperLongitude}
   </select>
   <select id="findArticleDetails" resultMap="ArticleDetails">
-    select distinct a.id as articleId, a.id as id, a.title as title, a.content as content,
+    select a.id as articleId, a.id as id, a.title as title, a.content as content,
     a.latitude as latitude, a.longitude as longitude, a.member_id as writerId,
     m.nick_name as writerName, m.image_url as writerImageUrl, a.create_date as createDate,
     (SELECT count(l.id) FROM article a LEFT JOIN article_like l ON a.id = l.article_id
@@ -29,16 +29,16 @@
     (SELECT EXISTS ( SELECT 1 FROM article_like
     WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
     c.id as commentId, c.content as commentContent, c.member_id as memberId, cm.nick_name as nickName,
-    cm.image_url as imageUrl, c.create_date as commentCreateDate, count(cl.id) as commentTotalLikes,
-    FROM article a JOIN member m ON a.member_id = m.id
-    LEFT JOIN comment c ON a.id = c.article_id LEFT JOIN comment_like cl ON c.id = cl.comment_id
-    JOIN member cm ON c.member_id = cm.id
+    cm.image_url as imageUrl, c.create_date as commentCreateDate, count(distinct cl.id) as commentTotalLikes
+    FROM article a JOIN member m ON (a.member_id = m.id)
+    LEFT JOIN comment c ON (a.id = c.article_id) LEFT JOIN comment_like cl ON c.id = cl.comment_id
+    LEFT JOIN member cm ON c.member_id = cm.id
     WHERE a.id = #{articleId}
     GROUP BY c.id
   </select>
   <resultMap id="ArticleDetails" type="ArticlePageDto">
     <id property="articleId" column="articleId"/>
-    <association property="articleDetails" javaType="ArticleDetailsDto2">
+    <association property="articleDetails" javaType="ArticleDetailsDto">
       <id property="id" column="id"/>
       <result property="title" column="title"/>
       <result property="content" column="content"/>
@@ -51,6 +51,45 @@
       <result property="totalLikes" column="totalLikes"/>
     </association>
     <association property="articleLike" javaType="boolean"/>
+    <collection property="comments" notNullColumn="commentId"
+      ofType="foot.footprint.domain.comment.dto.CommentsDto">
+      <id property="commentId" column="commentId"/>
+      <result property="commentContent" column="commentContent"/>
+      <result property="memberId" column="memberId"/>
+      <result property="nickName" column="nickName"/>
+      <result property="imageUrl" column="imageUrl"/>
+      <result property="commentCreateDate" column="commentCreateDate"/>
+      <result property="commentTotalLikes" column="commentTotalLikes"/>
+    </collection>
+  </resultMap>
+  <select id="findArticleDetailsIfNonLogin" resultMap="ArticleDetailsIfNonLogin">
+    select distinct a.id as articleId, a.id as id, a.title as title, a.content as content,
+    a.latitude as latitude, a.longitude as longitude, a.member_id as writerId,
+    m.nick_name as writerName, m.image_url as writerImageUrl, a.create_date as createDate,
+    (SELECT count(l.id) FROM article a LEFT JOIN article_like l ON a.id = l.article_id
+    WHERE a.id = #{articleId} GROUP BY a.id ) as totalLikes,
+    c.id as commentId, c.content as commentContent, c.member_id as memberId, cm.nick_name as nickName,
+    cm.image_url as imageUrl, c.create_date as commentCreateDate, count(cl.id) as commentTotalLikes
+    FROM article a JOIN member m ON a.member_id = m.id
+    LEFT JOIN comment c ON a.id = c.article_id LEFT JOIN comment_like cl ON c.id = cl.comment_id
+    LEFT JOIN member cm ON c.member_id = cm.id
+    WHERE a.id = #{articleId}
+    GROUP BY c.id
+  </select>
+  <resultMap id="ArticleDetailsIfNonLogin" type="ArticlePageIfNonLoginDto">
+    <id property="articleId" column="articleId"/>
+    <association property="articleDetails" javaType="ArticleDetailsDto">
+      <id property="id" column="id"/>
+      <result property="title" column="title"/>
+      <result property="content" column="content"/>
+      <result property="latitude" column="latitude"/>
+      <result property="longitude" column="longitude"/>
+      <result property="writerId" column="writerId"/>
+      <result property="writerName" column="writerName"/>
+      <result property="writerImageUrl" column="writerImageUrl"/>
+      <result property="createDate" column="createDate"/>
+      <result property="totalLikes" column="totalLikes"/>
+    </association>
     <collection property="comments" notNullColumn="commentId"
       ofType="foot.footprint.domain.comment.dto.CommentsDto">
       <id property="commentId" column="commentId"/>

--- a/backend/footprint/src/main/resources/mapper/group/ArticleGroupMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/group/ArticleGroupMapper.xml
@@ -16,9 +16,10 @@
     )
   </select>
   <delete id="deleteArticleGroup">
-    DELETE FROM article_group
-    WHERE id in (SELECT g.id FROM article a join article_group g ON a.id = g.article_id
-    WHERE a.member_id = #{memberId} AND g.group_id = #{groupId})
+    DELETE FROM article_group WHERE id in (
+    SELECT id FROM (SELECT g.id FROM article a join article_group g ON a.id = g.article_id
+    WHERE a.member_id = #{memberId} AND g.group_id = #{groupId}) as gt )
+
   </delete>
   <update id="changeGroupName">
     UPDATE group_table SET name = #{newName}

--- a/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/member/MemberMapper.xml
@@ -17,6 +17,7 @@
     FROM member m LEFT JOIN article a ON m.id = a.member_id LEFT JOIN comment c ON a.id = c.article_id
     LEFT JOIN article_like al ON a.id = al.article_id LEFT JOIN member_group mg ON m.id = mg.member_id
     LEFT JOIN group_table g ON mg.group_id = g.id WHERE m.id = #{memberId} GROUP BY a.id
+    ORDER BY a.create_date DESC
   </select>
   <resultMap id="myPageDetails" type="MyPageResponse">
     <id property="memberId" column="memberId"/>

--- a/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/RepositoryTest.java
@@ -3,6 +3,7 @@ package foot.footprint.repository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.articleLike.domain.ArticleLike;
 import foot.footprint.domain.comment.domain.Comment;
+import foot.footprint.domain.commentLike.domain.CommentLike;
 import foot.footprint.domain.group.domain.Group;
 import foot.footprint.domain.group.domain.MemberGroup;
 import foot.footprint.domain.member.domain.AuthProvider;
@@ -75,5 +76,11 @@ public class RepositoryTest {
             .group_id(groupId)
             .member_id(memberId)
             .important(true).build();
+    }
+
+    protected CommentLike buildCommentLike(Long commentId, Long memberId) {
+        return CommentLike.builder()
+            .comment_id(commentId)
+            .member_id(memberId).build();
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -147,10 +147,10 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         Article dummyArticle2 = buildArticle(member2.getId());
         createArticleRepository.saveArticle(dummyArticle2);
 
-        ArticleLike articleLike1 = buildArticleLike(member1.getId(), article.getId());
-        articleLikeRepository.saveArticleLike(articleLike1);
-        ArticleLike articleLike2 = buildArticleLike(member2.getId(), article.getId());
-        articleLikeRepository.saveArticleLike(articleLike2);
+//        ArticleLike articleLike1 = buildArticleLike(member1.getId(), article.getId());
+//        articleLikeRepository.saveArticleLike(articleLike1);
+//        ArticleLike articleLike2 = buildArticleLike(member2.getId(), article.getId());
+//        articleLikeRepository.saveArticleLike(articleLike2);
 
         Comment comment1 = buildComment(member1.getId(), article.getId());
         Comment comment2 = buildComment(member1.getId(), dummyArticle1.getId());
@@ -174,8 +174,8 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         assertThat(dto).isPresent();
         assertThat(dto.get().getArticleId()).isEqualTo(article.getId());
         assertThat(dto.get().getArticleDetails().getContent()).isEqualTo(article.getContent());
-        assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
-        assertThat(dto.get().isArticleLike()).isTrue();
+//        assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
+        assertThat(dto.get().isArticleLike()).isFalse();
         assertThat(dto.get().getComments().size()).isEqualTo(2);
         assertThat(dto.get().getComments().get(0).getNickName()).isEqualTo(member1.getNick_name());
         assertThat(dto.get().getComments().get(0).getMemberId()).isEqualTo(member1.getId());

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -168,19 +168,20 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         commentLikeRepository.saveCommentLike(commentLike3);
 
         //when
-        ArticlePageDto dto = findArticleRepository.findArticleDetails(article.getId(), member1.getId());
+        Optional<ArticlePageDto> dto = findArticleRepository.findArticleDetails(article.getId(), member1.getId());
 
         //then
-        assertThat(dto.getArticleId()).isEqualTo(article.getId());
-        assertThat(dto.getArticleDetails().getContent()).isEqualTo(article.getContent());
-        assertThat(dto.getArticleDetails().getTotalLikes()).isEqualTo(2);
-        assertThat(dto.isArticleLike()).isTrue();
-        assertThat(dto.getComments().size()).isEqualTo(2);
-        assertThat(dto.getComments().get(0).getNickName()).isEqualTo(member1.getNick_name());
-        assertThat(dto.getComments().get(0).getMemberId()).isEqualTo(member1.getId());
-        assertThat(dto.getComments().get(1).getMemberId()).isEqualTo(member2.getId());
-        assertThat(dto.getComments().get(0).getCommentTotalLikes()).isEqualTo(2L);
-        assertThat(dto.getComments().get(1).getCommentTotalLikes()).isEqualTo(1L);
+        assertThat(dto).isPresent();
+        assertThat(dto.get().getArticleId()).isEqualTo(article.getId());
+        assertThat(dto.get().getArticleDetails().getContent()).isEqualTo(article.getContent());
+        assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
+        assertThat(dto.get().isArticleLike()).isTrue();
+        assertThat(dto.get().getComments().size()).isEqualTo(2);
+        assertThat(dto.get().getComments().get(0).getNickName()).isEqualTo(member1.getNick_name());
+        assertThat(dto.get().getComments().get(0).getMemberId()).isEqualTo(member1.getId());
+        assertThat(dto.get().getComments().get(1).getMemberId()).isEqualTo(member2.getId());
+        assertThat(dto.get().getComments().get(0).getCommentTotalLikes()).isEqualTo(2L);
+        assertThat(dto.get().getComments().get(1).getCommentTotalLikes()).isEqualTo(1L);
     }
 
     private void saveArticle(double lat, double lng, boolean publicMap, boolean privateMap) {

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -147,10 +147,10 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         Article dummyArticle2 = buildArticle(member2.getId());
         createArticleRepository.saveArticle(dummyArticle2);
 
-//        ArticleLike articleLike1 = buildArticleLike(member1.getId(), article.getId());
-//        articleLikeRepository.saveArticleLike(articleLike1);
-//        ArticleLike articleLike2 = buildArticleLike(member2.getId(), article.getId());
-//        articleLikeRepository.saveArticleLike(articleLike2);
+        ArticleLike articleLike1 = buildArticleLike(member1.getId(), article.getId());
+        articleLikeRepository.saveArticleLike(articleLike1);
+        ArticleLike articleLike2 = buildArticleLike(member2.getId(), article.getId());
+        articleLikeRepository.saveArticleLike(articleLike2);
 
         Comment comment1 = buildComment(member1.getId(), article.getId());
         Comment comment2 = buildComment(member1.getId(), dummyArticle1.getId());
@@ -174,8 +174,8 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         assertThat(dto).isPresent();
         assertThat(dto.get().getArticleId()).isEqualTo(article.getId());
         assertThat(dto.get().getArticleDetails().getContent()).isEqualTo(article.getContent());
-//        assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
-        assertThat(dto.get().isArticleLike()).isFalse();
+        assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
+        assertThat(dto.get().isArticleLike()).isTrue();
         assertThat(dto.get().getComments().size()).isEqualTo(2);
         assertThat(dto.get().getComments().get(0).getNickName()).isEqualTo(member1.getNick_name());
         assertThat(dto.get().getComments().get(0).getMemberId()).isEqualTo(member1.getId());

--- a/backend/footprint/src/test/java/foot/footprint/repository/comment/FindCommentRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/comment/FindCommentRepositoryTest.java
@@ -49,11 +49,11 @@ public class FindCommentRepositoryTest extends RepositoryTest {
         Comment comment2 = buildComment(member2.getId(), article.getId());
         createCommentRepository.saveComment(comment2);
         //3개의 좋아요
-        CommentLike commentLike1 = createCommentLike(comment1.getId(), member1.getId());
+        CommentLike commentLike1 = buildCommentLike(comment1.getId(), member1.getId());
         commentLikeRepository.saveCommentLike(commentLike1);
-        CommentLike commentLike2 = createCommentLike(comment1.getId(), member2.getId());
+        CommentLike commentLike2 = buildCommentLike(comment1.getId(), member2.getId());
         commentLikeRepository.saveCommentLike(commentLike2);
-        CommentLike commentLike3 = createCommentLike(comment2.getId(), member1.getId());
+        CommentLike commentLike3 = buildCommentLike(comment2.getId(), member1.getId());
         commentLikeRepository.saveCommentLike(commentLike3);
 
         //when
@@ -61,9 +61,5 @@ public class FindCommentRepositoryTest extends RepositoryTest {
 
         //then
         assertThat(responses).hasSize(2);
-    }
-
-    private CommentLike createCommentLike(Long commentId, Long memberId) {
-        return CommentLike.builder().comment_id(commentId).member_id(memberId).build();
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/repository/commentLike/CommentLIkeRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/commentLike/CommentLIkeRepositoryTest.java
@@ -38,7 +38,7 @@ public class CommentLIkeRepositoryTest extends RepositoryTest {
         createArticleRepository.saveArticle(article);
         Comment comment = buildComment(member.getId(), article.getId());
         createCommentRepository.saveComment(comment);
-        CommentLike commentLike = createCommentLike(comment.getId(), member.getId());
+        CommentLike commentLike = buildCommentLike(comment.getId(), member.getId());
         //when
         commentLikeRepository.saveCommentLike(commentLike);
 
@@ -67,11 +67,11 @@ public class CommentLIkeRepositoryTest extends RepositoryTest {
         Comment comment4 = buildComment(another.getId(), article.getId());
         createCommentRepository.saveComment(comment4);
         //3개의 좋아요, 2개는 member 1개는 another
-        CommentLike commentLike1 = createCommentLike(comment1.getId(), member.getId());
+        CommentLike commentLike1 = buildCommentLike(comment1.getId(), member.getId());
         commentLikeRepository.saveCommentLike(commentLike1);
-        CommentLike commentLike2 = createCommentLike(comment2.getId(), another.getId());
+        CommentLike commentLike2 = buildCommentLike(comment2.getId(), another.getId());
         commentLikeRepository.saveCommentLike(commentLike2);
-        CommentLike commentLike4 = createCommentLike(comment4.getId(), member.getId());
+        CommentLike commentLike4 = buildCommentLike(comment4.getId(), member.getId());
         commentLikeRepository.saveCommentLike(commentLike4);
 
         //when
@@ -91,7 +91,7 @@ public class CommentLIkeRepositoryTest extends RepositoryTest {
         createArticleRepository.saveArticle(article);
         Comment comment = buildComment(member.getId(), article.getId());
         createCommentRepository.saveComment(comment);
-        CommentLike commentLike = createCommentLike(comment.getId(), member.getId());
+        CommentLike commentLike = buildCommentLike(comment.getId(), member.getId());
         commentLikeRepository.saveCommentLike(commentLike);
 
         //when
@@ -99,11 +99,5 @@ public class CommentLIkeRepositoryTest extends RepositoryTest {
 
         //that
         assertThat(result).isEqualTo(1);
-    }
-
-    private CommentLike createCommentLike(Long commentId, Long memberId) {
-        return CommentLike.builder()
-            .comment_id(commentId)
-            .member_id(memberId).build();
     }
 }

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
@@ -1,117 +1,117 @@
-package foot.footprint.service.article;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
-import foot.footprint.domain.article.application.findArticleDetails.FindPublicArticleDetails;
-import foot.footprint.domain.article.dao.FindArticleRepository;
-import foot.footprint.domain.article.domain.Article;
-import foot.footprint.domain.article.dto.ArticleDetailsDto;
-import foot.footprint.domain.article.dto.ArticlePageResponse;
-import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
-import foot.footprint.domain.comment.dao.FindCommentRepository;
-import foot.footprint.domain.comment.dto.CommentResponse;
-import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
-import foot.footprint.global.security.user.CustomUserDetails;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-public class FindArticleDetailsServiceTest {
-
-    @Mock
-    private FindArticleRepository findArticleRepository;
-
-    @Mock
-    private ArticleLikeRepository articleLikeRepository;
-
-    @Mock
-    private FindCommentRepository findCommentRepository;
-
-    @Mock
-    private CommentLikeRepository commentLikeRepository;
-
-
-    @InjectMocks
-    private FindPublicArticleDetails findPublicArticleDetails;
-
-    @BeforeEach
-    void setUp() {
-        Long memberId = 4L;
-        Long articleId = 10L;
-        //게시글 리턴
-        Article article = buildArticle(memberId, true, true);
-        given(findArticleRepository.findById(any())).willReturn(Optional.ofNullable(article));
-        //게시글 dto 리턴
-        ArticleDetailsDto details = new ArticleDetailsDto(articleId, "title", "content", 1.0, 1.0,
-            memberId, "nickName", "image", new Date(), 0L);
-        given(findArticleRepository.findArticleDetails(any())).willReturn(details);
-        //댓글 리스트 리턴
-        CommentResponse response = new CommentResponse(1L, "test", memberId, "nickName", "image",
-            new Date(), 0L);
-        List<CommentResponse> responses = new ArrayList<>();
-        responses.add(response);
-        given(findCommentRepository.findAllByArticleId(any())).willReturn(responses);
-        //게시글 좋아요 검증 리턴
-        given(articleLikeRepository.existsMyLike(any()))
-            .willReturn(true);
-        //댓글 좋아요 리스트 리턴
-        List<Long> commentLikes = new ArrayList<>();
-        commentLikes.add(1L);
-        given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
-            new ArrayList<>(commentLikes));
-    }
-
-    @Test
-    @DisplayName("게시글 조회 - 전체공개시")
-    public void findDetails() {
-        //given
-        Long memberId = 4L;
-        String email = "email@test.com";
-        Long articleId = 10L;
-        CustomUserDetails userDetails = new CustomUserDetails(memberId, email, null);
-
-        //when
-        ArticlePageResponse response = findPublicArticleDetails.findDetails(articleId,
-            userDetails);
-
-        //then
-        assertThat(response.getArticleDetails().getId()).isEqualTo(articleId);
-        assertThat(response.getComments().size()).isEqualTo(1);
-        assertThat(response.getCommentLikes().get(0)).isEqualTo(1L);
-        assertThat(response.isArticleLike()).isTrue();
-        assertThat(response.getMyMemberId()).isEqualTo(memberId);
-
-        //when 유저 정보가 null(로그인하지 않는 상태)
-        ArticlePageResponse response2 = findPublicArticleDetails.findDetails(articleId, null);
-
-        //then
-        assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);
-        assertThat(response2.getComments().size()).isEqualTo(1);
-        assertThat(response2.getCommentLikes()).isEmpty();
-        assertThat(response2.isArticleLike()).isFalse();
-        assertThat(response2.getMyMemberId()).isEqualTo(-1L);
-    }
-
-    private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
-        return Article.builder()
-            .content("test")
-            .latitude(10.0)
-            .longitude(10.0)
-            .public_map(publicMap)
-            .private_map(privateMap)
-            .title("test")
-            .create_date(new Date())
-            .member_id(memberId).build();
-    }
-}
+//package foot.footprint.service.article;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.BDDMockito.given;
+//
+//import foot.footprint.domain.article.application.findArticleDetails.FindPublicArticleDetails;
+//import foot.footprint.domain.article.dao.FindArticleRepository;
+//import foot.footprint.domain.article.domain.Article;
+//import foot.footprint.domain.article.dto.ArticleDetailsDto;
+//import foot.footprint.domain.article.dto.ArticlePageResponse;
+//import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
+//import foot.footprint.domain.comment.dao.FindCommentRepository;
+//import foot.footprint.domain.comment.dto.CommentResponse;
+//import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
+//import foot.footprint.global.security.user.CustomUserDetails;
+//import java.util.ArrayList;
+//import java.util.Date;
+//import java.util.List;
+//import java.util.Optional;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//@ExtendWith(MockitoExtension.class)
+//public class FindArticleDetailsServiceTest {
+//
+//    @Mock
+//    private FindArticleRepository findArticleRepository;
+//
+//    @Mock
+//    private ArticleLikeRepository articleLikeRepository;
+//
+//    @Mock
+//    private FindCommentRepository findCommentRepository;
+//
+//    @Mock
+//    private CommentLikeRepository commentLikeRepository;
+//
+//
+//    @InjectMocks
+//    private FindPublicArticleDetails findPublicArticleDetails;
+//
+//    @BeforeEach
+//    void setUp() {
+//        Long memberId = 4L;
+//        Long articleId = 10L;
+//        //게시글 리턴
+//        Article article = buildArticle(memberId, true, true);
+//        given(findArticleRepository.findById(any())).willReturn(Optional.ofNullable(article));
+//        //게시글 dto 리턴
+//        ArticleDetailsDto details = new ArticleDetailsDto(articleId, "title", "content", 1.0, 1.0,
+//            memberId, "nickName", "image", new Date(), 0L);
+//        given(findArticleRepository.findArticleDetails(any())).willReturn(details);
+//        //댓글 리스트 리턴
+//        CommentResponse response = new CommentResponse(1L, "test", memberId, "nickName", "image",
+//            new Date(), 0L);
+//        List<CommentResponse> responses = new ArrayList<>();
+//        responses.add(response);
+//        given(findCommentRepository.findAllByArticleId(any())).willReturn(responses);
+//        //게시글 좋아요 검증 리턴
+//        given(articleLikeRepository.existsMyLike(any()))
+//            .willReturn(true);
+//        //댓글 좋아요 리스트 리턴
+//        List<Long> commentLikes = new ArrayList<>();
+//        commentLikes.add(1L);
+//        given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
+//            new ArrayList<>(commentLikes));
+//    }
+//
+//    @Test
+//    @DisplayName("게시글 조회 - 전체공개시")
+//    public void findDetails() {
+//        //given
+//        Long memberId = 4L;
+//        String email = "email@test.com";
+//        Long articleId = 10L;
+//        CustomUserDetails userDetails = new CustomUserDetails(memberId, email, null);
+//
+//        //when
+//        ArticlePageResponse response = findPublicArticleDetails.findDetails(articleId,
+//            userDetails);
+//
+//        //then
+//        assertThat(response.getArticleDetails().getId()).isEqualTo(articleId);
+//        assertThat(response.getComments().size()).isEqualTo(1);
+//        assertThat(response.getCommentLikes().get(0)).isEqualTo(1L);
+//        assertThat(response.isArticleLike()).isTrue();
+//        assertThat(response.getMyMemberId()).isEqualTo(memberId);
+//
+//        //when 유저 정보가 null(로그인하지 않는 상태)
+//        ArticlePageResponse response2 = findPublicArticleDetails.findDetails(articleId, null);
+//
+//        //then
+//        assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);
+//        assertThat(response2.getComments().size()).isEqualTo(1);
+//        assertThat(response2.getCommentLikes()).isEmpty();
+//        assertThat(response2.isArticleLike()).isFalse();
+//        assertThat(response2.getMyMemberId()).isEqualTo(-1L);
+//    }
+//
+//    private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
+//        return Article.builder()
+//            .content("test")
+//            .latitude(10.0)
+//            .longitude(10.0)
+//            .public_map(publicMap)
+//            .private_map(privateMap)
+//            .title("test")
+//            .create_date(new Date())
+//            .member_id(memberId).build();
+//    }
+//}

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
@@ -1,117 +1,121 @@
-//package foot.footprint.service.article;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.BDDMockito.given;
-//
-//import foot.footprint.domain.article.application.findArticleDetails.FindPublicArticleDetails;
-//import foot.footprint.domain.article.dao.FindArticleRepository;
-//import foot.footprint.domain.article.domain.Article;
-//import foot.footprint.domain.article.dto.ArticleDetailsDto;
-//import foot.footprint.domain.article.dto.ArticlePageResponse;
-//import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
-//import foot.footprint.domain.comment.dao.FindCommentRepository;
-//import foot.footprint.domain.comment.dto.CommentResponse;
-//import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
-//import foot.footprint.global.security.user.CustomUserDetails;
-//import java.util.ArrayList;
-//import java.util.Date;
-//import java.util.List;
-//import java.util.Optional;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class FindArticleDetailsServiceTest {
-//
-//    @Mock
-//    private FindArticleRepository findArticleRepository;
-//
-//    @Mock
-//    private ArticleLikeRepository articleLikeRepository;
-//
-//    @Mock
-//    private FindCommentRepository findCommentRepository;
-//
-//    @Mock
-//    private CommentLikeRepository commentLikeRepository;
-//
-//
-//    @InjectMocks
-//    private FindPublicArticleDetails findPublicArticleDetails;
-//
-//    @BeforeEach
-//    void setUp() {
-//        Long memberId = 4L;
-//        Long articleId = 10L;
-//        //게시글 리턴
-//        Article article = buildArticle(memberId, true, true);
-//        given(findArticleRepository.findById(any())).willReturn(Optional.ofNullable(article));
-//        //게시글 dto 리턴
-//        ArticleDetailsDto details = new ArticleDetailsDto(articleId, "title", "content", 1.0, 1.0,
-//            memberId, "nickName", "image", new Date(), 0L);
-//        given(findArticleRepository.findArticleDetails(any())).willReturn(details);
-//        //댓글 리스트 리턴
-//        CommentResponse response = new CommentResponse(1L, "test", memberId, "nickName", "image",
-//            new Date(), 0L);
-//        List<CommentResponse> responses = new ArrayList<>();
-//        responses.add(response);
-//        given(findCommentRepository.findAllByArticleId(any())).willReturn(responses);
-//        //게시글 좋아요 검증 리턴
-//        given(articleLikeRepository.existsMyLike(any()))
-//            .willReturn(true);
-//        //댓글 좋아요 리스트 리턴
-//        List<Long> commentLikes = new ArrayList<>();
-//        commentLikes.add(1L);
-//        given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
-//            new ArrayList<>(commentLikes));
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 조회 - 전체공개시")
-//    public void findDetails() {
-//        //given
-//        Long memberId = 4L;
-//        String email = "email@test.com";
-//        Long articleId = 10L;
-//        CustomUserDetails userDetails = new CustomUserDetails(memberId, email, null);
-//
-//        //when
-//        ArticlePageResponse response = findPublicArticleDetails.findDetails(articleId,
-//            userDetails);
-//
-//        //then
-//        assertThat(response.getArticleDetails().getId()).isEqualTo(articleId);
-//        assertThat(response.getComments().size()).isEqualTo(1);
-//        assertThat(response.getCommentLikes().get(0)).isEqualTo(1L);
-//        assertThat(response.isArticleLike()).isTrue();
-//        assertThat(response.getMyMemberId()).isEqualTo(memberId);
-//
-//        //when 유저 정보가 null(로그인하지 않는 상태)
-//        ArticlePageResponse response2 = findPublicArticleDetails.findDetails(articleId, null);
-//
-//        //then
-//        assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);
-//        assertThat(response2.getComments().size()).isEqualTo(1);
-//        assertThat(response2.getCommentLikes()).isEmpty();
-//        assertThat(response2.isArticleLike()).isFalse();
-//        assertThat(response2.getMyMemberId()).isEqualTo(-1L);
-//    }
-//
-//    private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
-//        return Article.builder()
-//            .content("test")
-//            .latitude(10.0)
-//            .longitude(10.0)
-//            .public_map(publicMap)
-//            .private_map(privateMap)
-//            .title("test")
-//            .create_date(new Date())
-//            .member_id(memberId).build();
-//    }
-//}
+package foot.footprint.service.article;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import foot.footprint.domain.article.application.findArticleDetails.FindPublicArticleDetails;
+import foot.footprint.domain.article.dao.FindArticleRepository;
+import foot.footprint.domain.article.domain.Article;
+import foot.footprint.domain.article.dto.ArticleDetailsDto;
+import foot.footprint.domain.article.dto.ArticlePageDto;
+import foot.footprint.domain.article.dto.ArticlePageIfNonLoginDto;
+import foot.footprint.domain.article.dto.ArticlePageResponse;
+import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
+import foot.footprint.domain.comment.dao.FindCommentRepository;
+import foot.footprint.domain.comment.dto.CommentResponse;
+import foot.footprint.domain.comment.dto.CommentsDto;
+import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
+import foot.footprint.global.security.user.CustomUserDetails;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FindArticleDetailsServiceTest {
+
+    @Mock
+    private FindArticleRepository findArticleRepository;
+
+    @Mock
+    private ArticleLikeRepository articleLikeRepository;
+
+    @Mock
+    private FindCommentRepository findCommentRepository;
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+
+    @InjectMocks
+    private FindPublicArticleDetails findPublicArticleDetails;
+
+    @BeforeEach
+    void setUp() {
+        Long memberId = 4L;
+        Long articleId = 10L;
+        //게시글 리턴
+        Article article = buildArticle(memberId, true, true);
+        given(findArticleRepository.findById(any())).willReturn(Optional.ofNullable(article));
+        //게시글 dto 리턴
+        ArticleDetailsDto details = new ArticleDetailsDto(articleId, "title", "content", 1.0, 1.0,
+            memberId, "nickName", "image", new Date(), 0L);
+        CommentsDto response = new CommentsDto(1L, "test", memberId, "nickName", "image",
+            new Date(), 0L);
+        List<CommentsDto> responses = new ArrayList<>();
+        responses.add(response);
+        ArticlePageDto dto = new ArticlePageDto(articleId, details, true, responses);
+        given(findArticleRepository.findArticleDetails(any(), any())).willReturn(Optional.of(dto));
+        //댓글 좋아요 리스트 리턴
+        List<Long> commentLikes = new ArrayList<>();
+        commentLikes.add(1L);
+        given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
+            new ArrayList<>(commentLikes));
+        //게시글 dto 리턴, 만약 로그인 하지 않았을 시
+        ArticlePageIfNonLoginDto nonLoginDto = new ArticlePageIfNonLoginDto(articleId, details,
+            responses);
+        given(findArticleRepository.findArticleDetailsIfNonLogin(articleId)).willReturn(
+            Optional.of(nonLoginDto));
+    }
+
+    @Test
+    @DisplayName("게시글 조회 - 전체공개시")
+    public void findDetails() {
+        //given
+        Long memberId = 4L;
+        String email = "email@test.com";
+        Long articleId = 10L;
+        CustomUserDetails userDetails = new CustomUserDetails(memberId, email, null);
+
+        //when
+        ArticlePageResponse response = findPublicArticleDetails.findDetails(articleId,
+            userDetails);
+
+        //then
+        assertThat(response.getArticleDetails().getId()).isEqualTo(articleId);
+        assertThat(response.getComments().size()).isEqualTo(1);
+        assertThat(response.getCommentLikes().get(0)).isEqualTo(1L);
+        assertThat(response.isArticleLike()).isTrue();
+        assertThat(response.getMyMemberId()).isEqualTo(memberId);
+
+        //when 유저 정보가 null(로그인하지 않는 상태)
+        ArticlePageResponse response2 = findPublicArticleDetails.findDetails(articleId, null);
+
+        //then
+        assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);
+        assertThat(response2.getComments().size()).isEqualTo(1);
+        assertThat(response2.getCommentLikes()).isEmpty();
+        assertThat(response2.isArticleLike()).isFalse();
+        assertThat(response2.getMyMemberId()).isEqualTo(-1L);
+    }
+
+    private Article buildArticle(Long memberId, boolean publicMap, boolean privateMap) {
+        return Article.builder()
+            .content("test")
+            .latitude(10.0)
+            .longitude(10.0)
+            .public_map(publicMap)
+            .private_map(privateMap)
+            .title("test")
+            .create_date(new Date())
+            .member_id(memberId).build();
+    }
+}

--- a/backend/footprint/src/test/resources/init-table.sql
+++ b/backend/footprint/src/test/resources/init-table.sql
@@ -146,3 +146,7 @@ references member (id) on delete cascade;
 
 alter table comment_like
     add constraint comment_like_comment_id_member_id_unique unique (comment_id, member_id);
+
+create index public_map_index on article (public_map, latitude, longitude);
+
+create index private_map_index on article (member_id, private_map, latitude, longitude);

--- a/frontend/footprint/src/api/group/EditGroupNameApi.js
+++ b/frontend/footprint/src/api/group/EditGroupNameApi.js
@@ -18,7 +18,7 @@ const editGroupNameApi = ({ groupId, newGroupName, accessToken, history }) => {
   return axios.put(BACKEND_ADDRESS + "/groups/" + groupId, body, config)
     .catch(error => {
       if (error.response.status === 401 || error.response.status === 403) {
-        alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
+        alert(error.response.data.errorMessage);
         history.push("/login");
       } else if(error.response.status === 400 || error.response.status === 404) {
         alert(error.response.data.errorMessage);

--- a/frontend/footprint/src/api/group/FindGroupNameApi.js
+++ b/frontend/footprint/src/api/group/FindGroupNameApi.js
@@ -1,0 +1,34 @@
+import axios from "axios";
+import {BACKEND_ADDRESS} from "../../constants/ADDRESS";
+
+const findGroupNameApi = ({ groupId, accessToken, history }) => {
+  if (!accessToken) {
+    alert("로그인이 필요한 서비스입니다.")
+    history.push('/login');
+    return Promise.reject("토큰이 없음");
+  }
+  const config = {
+    headers: {
+      Authorization: "Bearer " + accessToken
+    }
+  }
+  return axios.get(BACKEND_ADDRESS + "/groups/" + groupId + "/name", config)
+  .then(response => {
+    if (response.status === 200) {
+      return response.data
+    }
+  })
+  .catch(error => {
+    if (error.response.status === 401 || error.response.status === 403) {
+      alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
+      history.push("/login");
+      return Promise.reject();
+    } else if(error.response.status === 400 || error.response.status === 404) {
+      alert(error.response.data.errorMessage);
+      history.push("/");
+      return Promise.reject();
+    } else alert("이유가 뭔지 모르겠지만 내 그룹을 불러오는데 실패했음...");
+  });
+};
+
+export default findGroupNameApi;

--- a/frontend/footprint/src/components/articleDetail/ArticleDetailPage.js
+++ b/frontend/footprint/src/components/articleDetail/ArticleDetailPage.js
@@ -83,8 +83,8 @@ const ArticleDetailPage = (props) => {
             author={
               article
                 ? {
-                    nickName: article ? article.writerNickName : "",
-                    imageUrl: article ? article.writerImageUrl : "",
+                    nickName: article.author ? article.author.nickName : "",
+                    imageUrl: article.author ? article.author.imageUrl : "",
                   }
                 : {
                     nickName: "",
@@ -107,7 +107,7 @@ const ArticleDetailPage = (props) => {
             hasILiked={hasILiked}
             setHasILiked={setHasILiked}
             history={props.history}
-            isMyArticle={article ? article.writerId === myId : false}
+            isMyArticle={article ? article.author.id === myId : false}
             setIsChangeContentModalOpened={setIsChangeContentModalOpeneded}
           />
         </PostBox>

--- a/frontend/footprint/src/components/articleDetail/ArticleDetailPage.js
+++ b/frontend/footprint/src/components/articleDetail/ArticleDetailPage.js
@@ -67,8 +67,7 @@ const ArticleDetailPage = (props) => {
       props.history.push("/");
     }
   }, [articleId, mapType]);
-console.log(groupId)
-console.log("dddddddddddddddddd")
+
   return (
     <Outside>
       <ChangeContentModal
@@ -84,8 +83,8 @@ console.log("dddddddddddddddddd")
             author={
               article
                 ? {
-                    nickName: article.author ? article.author.nickName : "",
-                    imageUrl: article.author ? article.author.imageUrl : "",
+                    nickName: article ? article.writerNickName : "",
+                    imageUrl: article ? article.writerImageUrl : "",
                   }
                 : {
                     nickName: "",
@@ -108,7 +107,7 @@ console.log("dddddddddddddddddd")
             hasILiked={hasILiked}
             setHasILiked={setHasILiked}
             history={props.history}
-            isMyArticle={article ? article.author.id === myId : false}
+            isMyArticle={article ? article.writerId === myId : false}
             setIsChangeContentModalOpened={setIsChangeContentModalOpeneded}
           />
         </PostBox>

--- a/frontend/footprint/src/components/articleDetail/ArticleMeta.js
+++ b/frontend/footprint/src/components/articleDetail/ArticleMeta.js
@@ -22,12 +22,12 @@ const ArticleMeta = (props) => {
         groupId={props.groupId}
     />
     <StyledDiv>
-      <Profile imageUrl={props.author? props.author.imageUrl : ""}/>
+      <Profile imageUrl={props? props.writerImageUrl : ""}/>
       <div style={{
         paddingTop: "5px",
       }}>
         <Name>
-          {props.author.nickName}
+          {props.writerNickName}
         </Name>
         <CreateDate iso8601format={props.createDate}/>
       </div>

--- a/frontend/footprint/src/components/articleDetail/ArticleMeta.js
+++ b/frontend/footprint/src/components/articleDetail/ArticleMeta.js
@@ -22,12 +22,12 @@ const ArticleMeta = (props) => {
         groupId={props.groupId}
     />
     <StyledDiv>
-      <Profile imageUrl={props? props.writerImageUrl : ""}/>
+      <Profile imageUrl={props.author? props.author.imageUrl : ""}/>
       <div style={{
         paddingTop: "5px",
       }}>
         <Name>
-          {props.writerNickName}
+          {props.author.nickName}
         </Name>
         <CreateDate iso8601format={props.createDate}/>
       </div>

--- a/frontend/footprint/src/components/home/DefaultMapPage.js
+++ b/frontend/footprint/src/components/home/DefaultMapPage.js
@@ -19,6 +19,7 @@ import CreateGroupModal from "./menu/group/create/CreateGroupModal";
 import JoinGroupModal from "./menu/group/join/JoinGroupModal";
 import MapType from "./MapTypeStyle";
 import MyLocationButton from "./button/MyLocationButton";
+import findGroupNameApi from "../../api/group/FindGroupNameApi";
 
 const DefaultMapPage = (props) => {
   


### PR DESCRIPTION
resolved: #69 

현재 게시글 상세 페이지 api 호출 시 db에 접근하는 횟수는 vaildate 1회(privaete or grouped 일 시), 데이터 가져올 때 4회이다. 이는 너무 많은 횟수이기에 이를 validate 1회 + 1회로 줄일 예정이다.

articleDetails, comments, commentLikes, myArticleLike 4가지의 정보를 가져오기에 4번의 조회가 있다. 

이러한 정보들을 한꺼번에 얻기 위해서 마이페이지 조회 시 사용했던 resultMap과 collection 을 사용하고자 한다.