### PR TITLE
refactor: 프론트 - 그룹 추방 버튼 그룹장은 안보이도록 수정

### DIFF
--- a/backend/footprint/.gitignore
+++ b/backend/footprint/.gitignore
@@ -30,6 +30,7 @@ out/
 !**/src/test/**/out/
 application-rds.properties
 application-oauth.properties
+*.log
 
 ### NetBeans ###
 /nbproject/private/

--- a/frontend/footprint/src/components/group/members/GroupMembers.js
+++ b/frontend/footprint/src/components/group/members/GroupMembers.js
@@ -5,12 +5,13 @@ const GroupMembers = ({members, group, accessToken}) => {
   return (
     <>
       {
-        members.map(member => <Member
-          userId={member.id}
-          nickname={member.nickName}
-          userImageUrl={member.imageUrl}
+        members.map((members, index) => <Member
+          userId={members.id}
+          nickname={members.nickName}
+          userImageUrl={members.imageUrl}
           group={group}
           accessToken={accessToken}
+          index={index}
         />)
       }
     </>

--- a/frontend/footprint/src/components/group/members/Member.js
+++ b/frontend/footprint/src/components/group/members/Member.js
@@ -3,7 +3,7 @@ import Profile from "./Profile";
 import Nickname from "./NickName";
 import DeportButton from './Deport';
 
-const Member = ({userId, nickname, userImageUrl, group, accessToken}) => {
+const Member = ({userId, nickname, userImageUrl, group, accessToken, index}) => {
   return (
     <div style={{
       display: "flex",
@@ -12,7 +12,7 @@ const Member = ({userId, nickname, userImageUrl, group, accessToken}) => {
     }}>
       <Profile userImageUrl={userImageUrl}/>
       <Nickname nickname={nickname}/>
-      {group.owner ?
+      {group.owner && index !== 0?
       <DeportButton 
         groupId={group.id} 
         userId={userId}


### PR DESCRIPTION
전에는 그룹 추방버튼이 그룹장에게도 보이며 그룹장 추방시 자신을 추방할 수 없다는 경고창으로 대체하였지만
map에 index를 추가하여 1번째 인덱스를 가진 그룹원(그룹장)은 추방버튼이 보이지 않도록 수정하였다.