### PR TITLE
refactor: 의미없는 config#bean 삭제

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/delete/DeleteGeneralArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/delete/DeleteGeneralArticleService.java
@@ -15,7 +15,7 @@ public class DeleteGeneralArticleService implements DeleteArticleService{
 
     @Override
     @Transactional
-    @CacheEvict(key = "#articleId", value = "articleDetails", cacheManager = "redisCacheManager")
+    @CacheEvict(key = "#articleId", value = "articleDetails")
     public void delete(Long articleId, Long memberId) {
         int result = deleteArticleRepository.deleteById(articleId, memberId);
         if (result == 0) {

--- a/backend/footprint/src/main/java/foot/footprint/global/config/RedisCacheConfig.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/config/RedisCacheConfig.java
@@ -26,24 +26,4 @@ public class RedisCacheConfig {
         redisTemplate.setConnectionFactory(connectionFactory);
         return redisTemplate;
     }
-
-    @Bean
-    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
-
-        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofSeconds(30))
-            .disableCachingNullValues()
-            .serializeKeysWith(RedisSerializationContext
-                .SerializationPair
-                .fromSerializer(new StringRedisSerializer()))
-            .serializeValuesWith(RedisSerializationContext
-                .SerializationPair
-                .fromSerializer(new GenericJackson2JsonRedisSerializer()));
-
-        return RedisCacheManager
-            .RedisCacheManagerBuilder
-            .fromConnectionFactory(redisConnectionFactory)
-            .cacheDefaults(redisCacheConfiguration)
-            .build();
-    }
 }


### PR DESCRIPTION
issue: #99
config 파일 내의 bean으로 등록한 redisCacheManager는 삭제시에는 굳이 설정을 할 필요가 없기에 제거하였다.