### PR TITLE
refactor: 댓글 다음 페이지 조회시, 다음페이지 유무를 판단하는 로직 리펙토링

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/find/FindCommentOnPageService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/find/FindCommentOnPageService.java
@@ -19,7 +19,7 @@ public class FindCommentOnPageService implements FindCommentService {
     public CommentOnPageResponse findComments(Long articleId, Long cursorId) {
         List<CommentResponse> comments = findCommentRepository.findAllByArticleIdOnPage(articleId,
             cursorId);
-        if (comments.size() < 10) {
+        if (comments.size() < 11) {
             return new CommentOnPageResponse(comments);
         }
         return new CommentOnPageResponse(comments, comments.get(9).getId());

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentOnPageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentOnPageResponse.java
@@ -18,7 +18,7 @@ public class CommentOnPageResponse {
     }
 
     public CommentOnPageResponse(List<CommentResponse> comments, Long cursorId) {
-        this.comments = comments;
+        this.comments = comments.subList(0, 10);
         this.cursorId = cursorId;
         hasNextPage = true;
     }

--- a/backend/footprint/src/main/resources/mapper/comment/FindCommentMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/comment/FindCommentMapper.xml
@@ -25,7 +25,7 @@
     <if test="cursorId !=null">
       AND c.id &lt; #{cursorId}
     </if>
-    GROUP BY c.id ORDER BY c.id desc LIMIT 10
+    GROUP BY c.id ORDER BY c.id desc LIMIT 11
   </select>
   <resultMap id="findCommentsOnNextPage" type="CommentResponse">
     <id property="id" column="id"/>


### PR DESCRIPTION
이전에는 댓글 다음페이지 조회시 LIMIT를 10으로 설정하고, Service 메서드에서 댓글리스트의 사이즈가 10일 경우 다음페이지가 있는 것으로 하였다. 하지만 이렇게 되면 11번째의 댓글이 없다고 해도 다음페이지가 있는 것으로 여기고, 다음페이지를 조회하면 0개의 댓글이 반환될 것이다. 에러를 일으키진 않지만 불필요한 DB접근이 일어나는 것이다.

그래서 LIMIT를 11로 변경하여 11번째 댓글이 있을 경우, 다음페이지가 있는 것으로 리펙토링하였다.