### PR TITLE
Refactor#16: 게시 글 조회 - 통합된 메서드를 다시 분리

### DIFF
--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/edit/EditGeneralArticleService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/edit/EditGeneralArticleService.java
@@ -23,7 +23,7 @@ public class EditGeneralArticleService implements EditArticleService {
         if (result == 0) {
             throw new NotMatchMemberException("글이 존재하지 않거나 수정할 권한이 없습니다.");
         }
-        String redisKey = "articleDetails::" + articleId + ":" + memberId;
+        String redisKey = "articleDetails::" + articleId;
         objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.EDIT_ARTICLE, newContent);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/AbstrastFindArticleDetailsService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/AbstrastFindArticleDetailsService.java
@@ -39,7 +39,7 @@ public abstract class AbstrastFindArticleDetailsService implements FindArticleDe
         // redis에 데이터가 있을 경우 - DB 접근 x
         if (cache.isPresent()) {
             response.addNonLoginInfo(cache.get().getArticleDetails(), cache.get().getComments());
-            objectSerializer.saveData(redisKey, cache.get(), 10);
+            objectSerializer.saveData(redisKey, cache.get(), 60);
             return;
         }
         // redis에 데이터가 없을 경우 - DB 접근 o
@@ -47,7 +47,7 @@ public abstract class AbstrastFindArticleDetailsService implements FindArticleDe
             .orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
         response.addNonLoginInfo(dto.getArticleDetails(), dto.getComments());
         //redis에 저장
-        objectSerializer.saveData(redisKey, dto, 10);
+        objectSerializer.saveData(redisKey, dto, 60);
     }
 
     protected void addLoginInfo(Long articleId, Long memberId, ArticlePageResponse response) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/AbstrastFindArticleDetailsService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/AbstrastFindArticleDetailsService.java
@@ -4,6 +4,7 @@ import foot.footprint.domain.article.dao.FindArticleRepository;
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.dto.articleDetails.ArticlePageDto;
 import foot.footprint.domain.article.dto.articleDetails.ArticlePageResponse;
+import foot.footprint.domain.article.dto.articleDetails.ArticlePrivateDetailsDto;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.comment.dao.FindCommentRepository;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
@@ -11,7 +12,6 @@ import foot.footprint.global.error.exception.NotAuthorizedOrExistException;
 import foot.footprint.global.error.exception.NotExistsException;
 import foot.footprint.global.security.user.CustomUserDetails;
 import foot.footprint.global.util.ObjectSerializer;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -41,9 +41,10 @@ public abstract class AbstrastFindArticleDetailsService implements FindArticleDe
     protected void addLoginInfo(Long articleId, Long memberId, ArticlePageResponse response) {
         ArticlePageDto dto = findArticleRepository.findArticleDetails(articleId)
             .orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
-        List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(articleId, memberId);
+        ArticlePrivateDetailsDto privateDto = findArticleRepository.findArticlePrivateDetails(
+            articleId, memberId).orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
         response.addNonLoginInfo(dto.getArticleDetails(), dto.getComments());
-        response.addLoginInfo(true, commentLikes, memberId);
+        response.addLoginInfo(privateDto.isArticleLike(), privateDto.getCommentLikes(), memberId);
     }
 
     protected void validateMember(CustomUserDetails userDetails) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/AbstrastFindArticleDetailsService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/AbstrastFindArticleDetailsService.java
@@ -33,17 +33,17 @@ public abstract class AbstrastFindArticleDetailsService implements FindArticleDe
     }
 
     protected void addNonLoginInfo(Long articleId, ArticlePageResponse response) {
-        ArticlePageDto dto = findArticleRepository.findArticleDetails(articleId, null)
+        ArticlePageDto dto = findArticleRepository.findArticleDetails(articleId)
             .orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
         response.addNonLoginInfo(dto.getArticleDetails(), dto.getComments());
     }
 
     protected void addLoginInfo(Long articleId, Long memberId, ArticlePageResponse response) {
-        ArticlePageDto dto = findArticleRepository.findArticleDetails(articleId, memberId)
+        ArticlePageDto dto = findArticleRepository.findArticleDetails(articleId)
             .orElseThrow(() -> new NotExistsException("해당 게시글이 존재하지 않습니다."));
         List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(articleId, memberId);
         response.addNonLoginInfo(dto.getArticleDetails(), dto.getComments());
-        response.addLoginInfo(dto.isArticleLike(), commentLikes, memberId);
+        response.addLoginInfo(true, commentLikes, memberId);
     }
 
     protected void validateMember(CustomUserDetails userDetails) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindGroupedArticleDetailsService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindGroupedArticleDetailsService.java
@@ -9,7 +9,6 @@ import foot.footprint.domain.group.dao.ArticleGroupRepository;
 import foot.footprint.global.security.user.CustomUserDetails;
 import foot.footprint.global.util.ObjectSerializer;
 import foot.footprint.global.util.ValidateIsMine;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,18 +36,9 @@ public class FindGroupedArticleDetailsService extends AbstrastFindArticleDetails
     public ArticlePageResponse findDetails(Long articleId, CustomUserDetails userDetails) {
         validateMember(userDetails);
         ValidateIsMine.validateInMyGroup(articleId, userDetails.getId(), articleGroupRepository);
-        String redisKey = "articleDetails::" + articleId + ":" + userDetails.getId();
-        Optional<ArticlePageResponse> cache = objectSerializer.getData(redisKey,
-            ArticlePageResponse.class);
-        // redis에 데이터가 있을 경우 - DB 접근 x
-        if (cache.isPresent()) {
-            return cache.get();
-        }
-        // redis에 데이터가 없을 경우 - DB 접근 o
         ArticlePageResponse response = new ArticlePageResponse();
+        addNonLoginInfo(response, articleId);
         addLoginInfo(articleId, userDetails.getId(), response);
-        // redis에 저장
-        objectSerializer.saveData(redisKey, response, 10);
         return response;
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPrivateArticleDetailsService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/application/findArticleDetails/FindPrivateArticleDetailsService.java
@@ -9,7 +9,6 @@ import foot.footprint.global.error.exception.WrongMapTypeException;
 import foot.footprint.global.security.user.CustomUserDetails;
 import foot.footprint.global.util.ObjectSerializer;
 import foot.footprint.global.util.ValidateIsMine;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,20 +28,10 @@ public class FindPrivateArticleDetailsService extends AbstrastFindArticleDetails
     @Transactional(readOnly = true)
     public ArticlePageResponse findDetails(Long articleId, CustomUserDetails userDetails) {
         validateMember(userDetails);
-        String redisKey = "articleDetails::" + articleId + ":" + userDetails.getId();
-        Optional<ArticlePageResponse> cache = objectSerializer.getData(redisKey,
-            ArticlePageResponse.class);
-        // redis에 데이터가 있을 경우 - DB 접근 x
-        if (cache.isPresent()) {
-            validatePrivateArticle(cache.get(), userDetails.getId());
-            return cache.get();
-        }
-        // redis에 데이터가 없을 경우 - DB 접근 o
         ArticlePageResponse response = new ArticlePageResponse();
+        addNonLoginInfo(response, articleId);
         addLoginInfo(articleId, userDetails.getId(), response);
         validatePrivateArticle(response, userDetails.getId());
-        // redis에 저장
-        objectSerializer.saveData(redisKey, response, 10);
         return response;
     }
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -23,5 +23,5 @@ public interface FindArticleRepository {
     @Select("Select * from article where id=#{articleId}")
     Optional<Article> findById(Long articleId);
 
-    Optional<ArticlePageDto> findArticleDetails(Long articleId, Long memberId);
+    Optional<ArticlePageDto> findArticleDetails(Long articleId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dao/FindArticleRepository.java
@@ -2,6 +2,7 @@ package foot.footprint.domain.article.dao;
 
 import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.domain.LocationRange;
+import foot.footprint.domain.article.dto.articleDetails.ArticlePrivateDetailsDto;
 import foot.footprint.domain.article.dto.articleDetails.ArticlePageDto;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
@@ -24,4 +25,6 @@ public interface FindArticleRepository {
     Optional<Article> findById(Long articleId);
 
     Optional<ArticlePageDto> findArticleDetails(Long articleId);
+
+    Optional<ArticlePrivateDetailsDto> findArticlePrivateDetails(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetails.java
@@ -40,8 +40,4 @@ public class ArticleDetails {
             dto.getLongitude(), dto.isPublicMap(), dto.isPrivateMap(), dto.getWriterId(),
             dto.getWriterName(), dto.getWriterImageUrl(), dto.getCreateDate(), dto.getTotalLikes());
     }
-
-    public void editContent(String content) {
-        this.content = content;
-    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetails.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetails.java
@@ -44,8 +44,4 @@ public class ArticleDetails {
     public void editContent(String content) {
         this.content = content;
     }
-
-    public void updateTotalLikes(Long num) {
-        totalLikes += num;
-    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetailsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetailsDto.java
@@ -22,4 +22,8 @@ public class ArticleDetailsDto {
     private String writerImageUrl;
     private Date createDate;
     private Long totalLikes;
+
+    public void updateTotalLikes(Long num) {
+        totalLikes += num;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetailsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleDetailsDto.java
@@ -26,4 +26,8 @@ public class ArticleDetailsDto {
     public void updateTotalLikes(Long num) {
         totalLikes += num;
     }
+
+    public void editContent(String content) {
+        this.content = content;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.dto.articleDetails;
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
+import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -48,12 +49,12 @@ public class ArticlePageDto {
 //        }
 //    }
 //
-//    public void changeCommentContent(CommentUpdateDto dto) {
-//        for (CommentResponse comment : comments) {
-//            if (comment.getId().equals(dto.getId())) {
-//                comment.editContent(dto.getNewContent());
-//                break;
-//            }
-//        }
-//    }
+    public void changeCommentContent(CommentUpdateDto dto) {
+        for (CommentsDto comment : comments) {
+            if (comment.getCommentId().equals(dto.getId())) {
+                comment.editContent(dto.getNewContent());
+                break;
+            }
+        }
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.dto.articleDetails;
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
+import foot.footprint.domain.commentLike.dto.ChangeTotalLikesDto;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ArticlePageDto {
+
     private Long articleId;
     private ArticleDetailsDto articleDetails;
     private List<CommentsDto> comments;
@@ -34,21 +36,17 @@ public class ArticlePageDto {
 //            }
 //        }
 //    }
-//
-//    public void changeCommentLike(Long commentId) {
-//        Long num = -1L;
-//        if (!commentLikes.remove(commentId)) {
-//            commentLikes.add(commentId);
-//            num = -num;
-//        }
-//        for (CommentResponse comment : comments) {
-//            if (comment.getId().equals(commentId)) {
-//                comment.updateTotalLikes(num);
-//                break;
-//            }
-//        }
-//    }
-//
+
+    public void changeCommentLike(ChangeTotalLikesDto dto) {
+        for (CommentsDto comment : comments) {
+            if (comment.getCommentId().equals(dto.getCommentId())) {
+                Long num = dto.isHasLiked() ? -1L : 1L;
+                comment.updateTotalLikes(num);
+                break;
+            }
+        }
+    }
+
     public void changeCommentContent(CommentUpdateDto dto) {
         for (CommentsDto comment : comments) {
             if (comment.getCommentId().equals(dto.getId())) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
@@ -21,9 +21,9 @@ public class ArticlePageDto {
         articleDetails.updateTotalLikes(changeNum);
     }
 
-//    public void addComment(CommentResponse comment) {
-//        comments.add(0, comment);
-//    }
+    public void addComment(CommentsDto comment) {
+        comments.add(0, comment);
+    }
 //
 //    public void removeComment(Long commentId) {
 //        for (int i = 0; i < comments.size(); i++) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
@@ -12,6 +12,5 @@ import lombok.NoArgsConstructor;
 public class ArticlePageDto {
     private Long articleId;
     private ArticleDetailsDto articleDetails;
-    private boolean articleLike;
     private List<CommentsDto> comments;
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
@@ -1,5 +1,7 @@
 package foot.footprint.domain.article.dto.articleDetails;
 
+import foot.footprint.domain.comment.dto.CommentResponse;
+import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -13,4 +15,45 @@ public class ArticlePageDto {
     private Long articleId;
     private ArticleDetailsDto articleDetails;
     private List<CommentsDto> comments;
+
+    public void changeLike(boolean hasLiked) {
+        Long changeNum = hasLiked ? -1L : 1L;
+        articleDetails.updateTotalLikes(changeNum);
+    }
+
+//    public void addComment(CommentResponse comment) {
+//        comments.add(0, comment);
+//    }
+//
+//    public void removeComment(Long commentId) {
+//        for (int i = 0; i < comments.size(); i++) {
+//            if (comments.get(i).getId().equals(commentId)) {
+//                comments.remove(i);
+//                break;
+//            }
+//        }
+//    }
+//
+//    public void changeCommentLike(Long commentId) {
+//        Long num = -1L;
+//        if (!commentLikes.remove(commentId)) {
+//            commentLikes.add(commentId);
+//            num = -num;
+//        }
+//        for (CommentResponse comment : comments) {
+//            if (comment.getId().equals(commentId)) {
+//                comment.updateTotalLikes(num);
+//                break;
+//            }
+//        }
+//    }
+//
+//    public void changeCommentContent(CommentUpdateDto dto) {
+//        for (CommentResponse comment : comments) {
+//            if (comment.getId().equals(dto.getId())) {
+//                comment.editContent(dto.getNewContent());
+//                break;
+//            }
+//        }
+//    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageDto.java
@@ -1,10 +1,8 @@
 package foot.footprint.domain.article.dto.articleDetails;
 
-import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
 import foot.footprint.domain.commentLike.dto.ChangeTotalLikesDto;
-import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,15 +25,15 @@ public class ArticlePageDto {
     public void addComment(CommentsDto comment) {
         comments.add(0, comment);
     }
-//
-//    public void removeComment(Long commentId) {
-//        for (int i = 0; i < comments.size(); i++) {
-//            if (comments.get(i).getId().equals(commentId)) {
-//                comments.remove(i);
-//                break;
-//            }
-//        }
-//    }
+
+    public void removeComment(Long commentId) {
+        for (int i = 0; i < comments.size(); i++) {
+            if (comments.get(i).getCommentId().equals(commentId)) {
+                comments.remove(i);
+                break;
+            }
+        }
+    }
 
     public void changeCommentLike(ChangeTotalLikesDto dto) {
         for (CommentsDto comment : comments) {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageResponse.java
@@ -35,10 +35,14 @@ public class ArticlePageResponse {
             .collect(Collectors.toList());
     }
 
-    public void addLoginInfo(boolean articleLike, List<MyCommentLikesInArticle> commentLikes, Long myMemberId) {
+    public void addLoginInfo(boolean articleLike, List<MyCommentLikesInArticle> commentLikes,
+        Long myMemberId) {
         this.articleLike = articleLike;
         for (MyCommentLikesInArticle commentLike : commentLikes) {
-            this.commentLikes.add(commentLike.getCommentId());
+            if (commentLike.hasMemberId() &&
+                commentLike.getMemberId().equals(myMemberId)) {
+                this.commentLikes.add(commentLike.getCommentId());
+            }
         }
         this.myMemberId = myMemberId;
     }
@@ -53,8 +57,8 @@ public class ArticlePageResponse {
         comments.add(0, comment);
     }
 
-    public void removeComment(Long commentId){
-        for (int i =0; i < comments.size(); i++) {
+    public void removeComment(Long commentId) {
+        for (int i = 0; i < comments.size(); i++) {
             if (comments.get(i).getId().equals(commentId)) {
                 comments.remove(i);
                 break;

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageResponse.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.dto.articleDetails;
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -13,7 +14,7 @@ public class ArticlePageResponse {
     private ArticleDetails articleDetails;
     private boolean articleLike;
     private List<CommentResponse> comments;
-    private List<Long> commentLikes;
+    private List<Long> commentLikes = new ArrayList<>();
     private Long myMemberId;
 
     public ArticlePageResponse(ArticleDetailsDto articleDetails, boolean articleLike,
@@ -34,9 +35,11 @@ public class ArticlePageResponse {
             .collect(Collectors.toList());
     }
 
-    public void addLoginInfo(boolean articleLike, List<Long> commentLikes, Long myMemberId) {
+    public void addLoginInfo(boolean articleLike, List<MyCommentLikesInArticle> commentLikes, Long myMemberId) {
         this.articleLike = articleLike;
-        this.commentLikes = commentLikes;
+        for (MyCommentLikesInArticle commentLike : commentLikes) {
+            this.commentLikes.add(commentLike.getCommentId());
+        }
         this.myMemberId = myMemberId;
     }
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePageResponse.java
@@ -1,7 +1,6 @@
 package foot.footprint.domain.article.dto.articleDetails;
 
 import foot.footprint.domain.comment.dto.CommentResponse;
-import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,47 +44,5 @@ public class ArticlePageResponse {
             }
         }
         this.myMemberId = myMemberId;
-    }
-
-    public void changeLike() {
-        Long changeNum = articleLike ? -1L : 1L;
-        articleDetails.updateTotalLikes(changeNum);
-        articleLike = !articleLike;
-    }
-
-    public void addComment(CommentResponse comment) {
-        comments.add(0, comment);
-    }
-
-    public void removeComment(Long commentId) {
-        for (int i = 0; i < comments.size(); i++) {
-            if (comments.get(i).getId().equals(commentId)) {
-                comments.remove(i);
-                break;
-            }
-        }
-    }
-
-    public void changeCommentLike(Long commentId) {
-        Long num = -1L;
-        if (!commentLikes.remove(commentId)) {
-            commentLikes.add(commentId);
-            num = -num;
-        }
-        for (CommentResponse comment : comments) {
-            if (comment.getId().equals(commentId)) {
-                comment.updateTotalLikes(num);
-                break;
-            }
-        }
-    }
-
-    public void changeCommentContent(CommentUpdateDto dto) {
-        for (CommentResponse comment : comments) {
-            if (comment.getId().equals(dto.getId())) {
-                comment.editContent(dto.getNewContent());
-                break;
-            }
-        }
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePrivateDetailsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticlePrivateDetailsDto.java
@@ -1,0 +1,15 @@
+package foot.footprint.domain.article.dto.articleDetails;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticlePrivateDetailsDto {
+    private Long articleId;
+    private boolean articleLike;
+    private List<MyCommentLikesInArticle> commentLikes;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
@@ -4,6 +4,7 @@ package foot.footprint.domain.article.dto.articleDetails;
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
+import foot.footprint.domain.commentLike.dto.ChangeTotalLikesDto;
 
 public enum ArticleUpdatePart {
 
@@ -14,7 +15,7 @@ public enum ArticleUpdatePart {
     },
     CHANGE_COMMENT_LIKE("change_comment_like") {
         public <T> void apply(ArticlePageDto dto, T data) {
-//            response.changeCommentLike((Long) data);
+            dto.changeCommentLike((ChangeTotalLikesDto) data);
         }
     },
     EDIT_ARTICLE("edit_article") {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
@@ -1,7 +1,5 @@
 package foot.footprint.domain.article.dto.articleDetails;
 
-
-import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
 import foot.footprint.domain.comment.dto.CommentsDto;
 import foot.footprint.domain.commentLike.dto.ChangeTotalLikesDto;
@@ -35,7 +33,7 @@ public enum ArticleUpdatePart {
     },
     REMOVE_COMMENT("remove_comment") {
         public <T> void apply(ArticlePageDto dto, T data) {
-//            response.removeComment((Long) data);
+            dto.removeComment((Long) data);
         }
     };
 

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
@@ -3,6 +3,7 @@ package foot.footprint.domain.article.dto.articleDetails;
 
 import foot.footprint.domain.comment.dto.CommentResponse;
 import foot.footprint.domain.comment.dto.CommentUpdateDto;
+import foot.footprint.domain.comment.dto.CommentsDto;
 
 public enum ArticleUpdatePart {
 
@@ -28,7 +29,7 @@ public enum ArticleUpdatePart {
     },
     ADD_COMMENT("add_comment") {
         public <T> void apply(ArticlePageDto dto, T data) {
-//            response.addComment((CommentResponse) data);
+            dto.addComment((CommentsDto) data);
         }
     },
     REMOVE_COMMENT("remove_comment") {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
@@ -7,38 +7,38 @@ import foot.footprint.domain.comment.dto.CommentUpdateDto;
 public enum ArticleUpdatePart {
 
     CHANGE_LIKE("change_like") {
-        public <T> void apply(ArticlePageResponse response, T data) {
-            response.changeLike();
+        public <T> void apply(ArticlePageDto dto, T data) {
+            dto.changeLike((boolean) data);
         }
     },
     CHANGE_COMMENT_LIKE("change_comment_like") {
-        public <T> void apply(ArticlePageResponse response, T data) {
-            response.changeCommentLike((Long) data);
+        public <T> void apply(ArticlePageDto dto, T data) {
+//            response.changeCommentLike((Long) data);
         }
     },
     EDIT_ARTICLE("edit_article") {
-        public <T> void apply(ArticlePageResponse response, T data) {
-            response.getArticleDetails().editContent((String) data);
+        public <T> void apply(ArticlePageDto dto, T data) {
+//            response.getArticleDetails().editContent((String) data);
         }
     },
     EDIT_COMMENT("edit_comment") {
-        public <T> void apply(ArticlePageResponse response, T data) {
-            response.changeCommentContent((CommentUpdateDto) data);
+        public <T> void apply(ArticlePageDto dto, T data) {
+//            response.changeCommentContent((CommentUpdateDto) data);
         }
     },
     ADD_COMMENT("add_comment") {
-        public <T> void apply(ArticlePageResponse response, T data) {
-            response.addComment((CommentResponse) data);
+        public <T> void apply(ArticlePageDto dto, T data) {
+//            response.addComment((CommentResponse) data);
         }
     },
     REMOVE_COMMENT("remove_comment") {
-        public <T> void apply(ArticlePageResponse response, T data) {
-            response.removeComment((Long) data);
+        public <T> void apply(ArticlePageDto dto, T data) {
+//            response.removeComment((Long) data);
         }
     };
 
     ArticleUpdatePart(String updatePart) {
     }
 
-    public abstract <T> void apply(ArticlePageResponse response, T data);
+    public abstract <T> void apply(ArticlePageDto dto, T data);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
@@ -24,7 +24,7 @@ public enum ArticleUpdatePart {
     },
     EDIT_COMMENT("edit_comment") {
         public <T> void apply(ArticlePageDto dto, T data) {
-//            response.changeCommentContent((CommentUpdateDto) data);
+            dto.changeCommentContent((CommentUpdateDto) data);
         }
     },
     ADD_COMMENT("add_comment") {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/ArticleUpdatePart.java
@@ -19,7 +19,7 @@ public enum ArticleUpdatePart {
     },
     EDIT_ARTICLE("edit_article") {
         public <T> void apply(ArticlePageDto dto, T data) {
-//            response.getArticleDetails().editContent((String) data);
+            dto.getArticleDetails().editContent((String) data);
         }
     },
     EDIT_COMMENT("edit_comment") {

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/MyCommentLikesInArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/MyCommentLikesInArticle.java
@@ -9,4 +9,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MyCommentLikesInArticle {
     private Long commentId;
+    private Long memberId;
+
+    public boolean hasMemberId(){
+        return this.memberId != null;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/MyCommentLikesInArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/article/dto/articleDetails/MyCommentLikesInArticle.java
@@ -1,0 +1,12 @@
+package foot.footprint.domain.article.dto.articleDetails;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyCommentLikesInArticle {
+    private Long commentId;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/AbstractChangeArticleLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/articleLike/application/AbstractChangeArticleLikeService.java
@@ -39,7 +39,8 @@ public abstract class AbstractChangeArticleLikeService implements ChangeArticleL
 
     protected void updateRedis(ArticleLikeDto articleLikeDto) {
         String redisKey =
-            "articleDetails::" + articleLikeDto.getArticleId() + ":" + articleLikeDto.getMemberId();
-        objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.CHANGE_LIKE, null);
+            "articleDetails::" + articleLikeDto.getArticleId();
+        objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.CHANGE_LIKE,
+            articleLikeDto.isHasILiked());
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/AbstractCreateCommentService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/AbstractCreateCommentService.java
@@ -6,6 +6,7 @@ import foot.footprint.domain.article.dto.articleDetails.ArticleUpdatePart;
 import foot.footprint.domain.comment.dao.CreateCommentRepository;
 import foot.footprint.domain.comment.domain.Comment;
 import foot.footprint.domain.comment.dto.CommentResponse;
+import foot.footprint.domain.comment.dto.CommentsDto;
 import foot.footprint.domain.member.dao.MemberRepository;
 import foot.footprint.domain.member.domain.Member;
 import foot.footprint.global.domain.AuthorDto;
@@ -38,8 +39,9 @@ public abstract class AbstractCreateCommentService implements CreateCommentServi
             .orElseThrow(() -> new NotExistsException("해당하는 회원이 존재하지 않습니다."));
     }
 
-    protected void updateRedis (Long articleId, Long memberId, CommentResponse response) {
-        String redisKey = "articleDetails::" + articleId + ":" + memberId;
-        objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.ADD_COMMENT, response);
+    protected void updateRedis (Long articleId, CommentResponse response) {
+        String redisKey = "articleDetails::" + articleId;
+        CommentsDto dto = CommentsDto.toDto(response);
+        objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.ADD_COMMENT, dto);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnGroupedArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnGroupedArticle.java
@@ -37,7 +37,7 @@ public class CreateCommentOnGroupedArticle extends AbstractCreateCommentService 
         AuthorDto authorDto = AuthorDto.buildAuthorDto(member);
         ValidateIsMine.validateInMyGroup(articleId, authorDto.getId(), articleGroupRepository);
         CommentResponse response = saveComment(articleId, content, authorDto);
-        updateRedis(articleId, memberId, response);
+        updateRedis(articleId, response);
         return response;
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPrivateArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPrivateArticle.java
@@ -38,7 +38,7 @@ public class CreateCommentOnPrivateArticle extends AbstractCreateCommentService 
         ValidateIsMine.validateArticleIsMine(article.getMember_id(), authorDto.getId());
 
         CommentResponse response = saveComment(articleId, content, authorDto);
-        updateRedis(articleId, memberId, response);
+        updateRedis(articleId, response);
         return response;
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPublicArticle.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/create/CreateCommentOnPublicArticle.java
@@ -34,7 +34,7 @@ public class CreateCommentOnPublicArticle extends AbstractCreateCommentService {
         }
         Member member = findAndValidateMember(memberId);
         CommentResponse response = saveComment(id, content, AuthorDto.buildAuthorDto(member));
-        updateRedis(id, memberId, response);
+        updateRedis(id, response);
         return response;
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/delete/DeleteGeneralCommentService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/delete/DeleteGeneralCommentService.java
@@ -23,7 +23,7 @@ public class DeleteGeneralCommentService implements DeleteCommentService {
         if (result == 0) {
             throw new NotMatchMemberException("댓글을 삭제할 권한이 없습니다.");
         }
-        String redisKey = "articleDetails::" + articleId + ":" + memberId;
+        String redisKey = "articleDetails::" + articleId;
         objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.REMOVE_COMMENT, commentId);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/application/edit/EditGeneralCommentService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/application/edit/EditGeneralCommentService.java
@@ -24,7 +24,7 @@ public class EditGeneralCommentService implements EditCommentService {
         if (result == 0) {
             throw new NotMatchMemberException("댓글을 수정할 권한이 없습니다.");
         }
-        String redisKey = "articleDetails::" + articleId + ":" + memberId;
+        String redisKey = "articleDetails::" + articleId;
         objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.EDIT_COMMENT,
             new CommentUpdateDto(commentId, newContent));
     }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentResponse.java
@@ -48,12 +48,4 @@ public class CommentResponse {
             commentsDto.getCommentTotalLikes()
         );
     }
-
-    public void editContent(String content){
-        this.content = content;
-    }
-
-    public void updateTotalLikes(Long num) {
-        totalLikes += num;
-    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentsDto.java
@@ -24,4 +24,12 @@ public class CommentsDto {
             response.getAuthor().getNickName(), response.getAuthor().getImageUrl(),
             response.getCreateDate(), response.getTotalLikes());
     }
+
+    public void editContent(String content){
+        this.commentContent = content;
+    }
+
+    public void updateTotalLikes(Long num) {
+        commentTotalLikes += num;
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentsDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/comment/dto/CommentsDto.java
@@ -1,5 +1,6 @@
 package foot.footprint.domain.comment.dto;
 
+import foot.footprint.global.domain.AuthorDto;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,4 +18,10 @@ public class CommentsDto {
     private String imageUrl;
     private Date commentCreateDate;
     private Long commentTotalLikes;
+
+    public static CommentsDto toDto(CommentResponse response){
+        return new CommentsDto(response.getId(), response.getContent(), response.getAuthor().getId(),
+            response.getAuthor().getNickName(), response.getAuthor().getImageUrl(),
+            response.getCreateDate(), response.getTotalLikes());
+    }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/AbstractChangeCommentLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/AbstractChangeCommentLikeService.java
@@ -5,6 +5,7 @@ import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.dto.articleDetails.ArticleUpdatePart;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
 import foot.footprint.domain.commentLike.domain.CommentLike;
+import foot.footprint.domain.commentLike.dto.ChangeTotalLikesDto;
 import foot.footprint.global.error.exception.NotExistsException;
 import foot.footprint.global.util.ObjectSerializer;
 import lombok.RequiredArgsConstructor;
@@ -38,9 +39,9 @@ public abstract class AbstractChangeCommentLikeService implements ChangeCommentL
         }
     }
 
-    protected void updateRedis(Long articleId, Long memberId, Long commentId) {
-        String redisKey = "articleDetails::" + articleId + ":" + memberId;
+    protected void updateRedis(Long articleId, Long commentId, boolean hasILiked) {
+        String redisKey = "articleDetails::" + articleId;
         objectSerializer.updateArticleData(redisKey, ArticleUpdatePart.CHANGE_COMMENT_LIKE,
-            commentId);
+            new ChangeTotalLikesDto(commentId, hasILiked));
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangeGroupedCommentLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangeGroupedCommentLikeService.java
@@ -30,6 +30,6 @@ public class ChangeGroupedCommentLikeService extends AbstractChangeCommentLikeSe
         findAndValidateArticle(articleId);
         ValidateIsMine.validateInMyGroup(articleId, memberId, articleGroupRepository);
         changeLike(commentId, memberId, hasILiked);
-        updateRedis(articleId, memberId, commentId);
+        updateRedis(articleId, commentId, hasILiked);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePrivateCommentLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePrivateCommentLikeService.java
@@ -30,6 +30,6 @@ public class ChangePrivateCommentLikeService extends AbstractChangeCommentLikeSe
         }
         ValidateIsMine.validateArticleIsMine(article.getMember_id(), memberId);
         changeLike(commentId, memberId, hasILiked);
-        updateRedis(articleId, memberId, commentId);
+        updateRedis(articleId, commentId, hasILiked);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePublicCommentLikeService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/application/ChangePublicCommentLikeService.java
@@ -28,6 +28,6 @@ public class ChangePublicCommentLikeService extends AbstractChangeCommentLikeSer
             throw new WrongMapTypeException("게시글이 전체지도에 포함되지 않습니다.");
         }
         changeLike(commentId, memberId, hasILiked);
-        updateRedis(articleId, memberId, commentId);
+        updateRedis(articleId, commentId, hasILiked);
     }
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/dao/CommentLikeRepository.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/dao/CommentLikeRepository.java
@@ -12,6 +12,4 @@ public interface CommentLikeRepository {
 
     @Delete("DELETE FROM comment_like WHERE comment_id=#{commentId} and member_id=#{memberId}")
     int deleteCommentLike(Long commentId, Long memberId);
-
-    List<Long> findCommentIdsILiked(Long articleId, Long memberId);
 }

--- a/backend/footprint/src/main/java/foot/footprint/domain/commentLike/dto/ChangeTotalLikesDto.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/commentLike/dto/ChangeTotalLikesDto.java
@@ -1,0 +1,14 @@
+package foot.footprint.domain.commentLike.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeTotalLikesDto {
+
+    private Long commentId;
+    private boolean hasLiked;
+}

--- a/backend/footprint/src/main/java/foot/footprint/domain/member/application/member/GeneralMemberService.java
+++ b/backend/footprint/src/main/java/foot/footprint/domain/member/application/member/GeneralMemberService.java
@@ -28,7 +28,7 @@ public class GeneralMemberService implements MemberService {
             return cacheData.get();
         }
         MemberImageResponse response = findByDB(memberId);
-        objectSerializer.saveData(redisKey, response, 10);
+        objectSerializer.saveData(redisKey, response, 30);
         return response;
     }
 
@@ -51,7 +51,7 @@ public class GeneralMemberService implements MemberService {
             return cache.get();
         }
         MyPageResponse response = memberRepository.findMyPageDetails(memberId);
-        objectSerializer.saveData(redisKey, response, 10);
+        objectSerializer.saveData(redisKey, response, 30);
         return response;
     }
 

--- a/backend/footprint/src/main/java/foot/footprint/global/util/ObjectSerializer.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/util/ObjectSerializer.java
@@ -1,7 +1,7 @@
 package foot.footprint.global.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import foot.footprint.domain.article.dto.articleDetails.ArticlePageResponse;
+import foot.footprint.domain.article.dto.articleDetails.ArticlePageDto;
 import foot.footprint.domain.article.dto.articleDetails.ArticleUpdatePart;
 import foot.footprint.global.error.exception.WrongAccessRedisException;
 import java.util.Optional;
@@ -44,7 +44,7 @@ public class ObjectSerializer {
     }
 
     public<T> void updateArticleData(String key, ArticleUpdatePart part, T data) {
-        Optional<ArticlePageResponse> cache = getData(key, ArticlePageResponse.class);
+        Optional<ArticlePageDto> cache = getData(key, ArticlePageDto.class);
         if (cache.isPresent()) {
             part.apply(cache.get(), data);
             saveData(key, cache.get(), 10);

--- a/backend/footprint/src/main/java/foot/footprint/global/util/ObjectSerializer.java
+++ b/backend/footprint/src/main/java/foot/footprint/global/util/ObjectSerializer.java
@@ -47,7 +47,7 @@ public class ObjectSerializer {
         Optional<ArticlePageDto> cache = getData(key, ArticlePageDto.class);
         if (cache.isPresent()) {
             part.apply(cache.get(), data);
-            saveData(key, cache.get(), 10);
+            saveData(key, cache.get(), 60);
         }
     }
 }

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -67,11 +67,14 @@
 
   <select id="findArticlePrivateDetails" resultMap="ArticlePrivateDetails">
     SELECT
-    #{articleId} as articleId,
+    a.id as articleId,
     (SELECT EXISTS ( SELECT 1 FROM article_like
     WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
-    (SELECT c.id FROM comment c JOIN comment_like l ON c.id = l.comment_id
-    WHERE c.article_id = #{articleId} AND l.member_id=#{memberId}) as commentId
+    c.id as commentId,
+    l.member_id as memberId
+    FROM article a LEFT JOIN comment c ON a.id = c.article_id
+    LEFT JOIN comment_like l ON c.id = l.comment_id
+    WHERE a.id = #{articleId}
   </select>
   <resultMap id="ArticlePrivateDetails" type="ArticlePrivateDetailsDto">
     <id property="articleId" column="articleId"/>
@@ -79,6 +82,7 @@
     <collection property="commentLikes" notNullColumn="commentId"
       ofType="foot.footprint.domain.article.dto.articleDetails.MyCommentLikesInArticle">
       <id property="commentId" column="commentId"/>
+      <result property="memberId" column="memberId"/>
     </collection>
   </resultMap>
 </mapper>

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -63,4 +63,22 @@
       <result property="commentTotalLikes" column="commentTotalLikes"/>
     </collection>
   </resultMap>
+
+
+  <select id="findArticlePrivateDetails" resultMap="ArticlePrivateDetails">
+    SELECT
+    #{articleId} as articleId,
+    (SELECT EXISTS ( SELECT 1 FROM article_like
+    WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
+    (SELECT c.id FROM comment c JOIN comment_like l ON c.id = l.comment_id
+    WHERE c.article_id = #{articleId} AND l.member_id=#{memberId}) as commentId
+  </select>
+  <resultMap id="ArticlePrivateDetails" type="ArticlePrivateDetailsDto">
+    <id property="articleId" column="articleId"/>
+    <id property="articleLike" column="articleLike"/>
+    <collection property="commentLikes" notNullColumn="commentId"
+      ofType="foot.footprint.domain.article.dto.articleDetails.MyCommentLikesInArticle">
+      <id property="commentId" column="commentId"/>
+    </collection>
+  </resultMap>
 </mapper>

--- a/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/article/FindArticleMapper.xml
@@ -22,15 +22,6 @@
   </select>
   <select id="findArticleDetails" resultMap="ArticleDetails">
     select a.id as articleId,
-    <choose>
-      <when test="memberId !=null">
-        (SELECT EXISTS ( SELECT 1 FROM article_like
-        WHERE article_id = #{articleId} and member_id =#{memberId} )) as articleLike,
-      </when>
-      <otherwise>
-        false as articleLike,
-      </otherwise>
-    </choose>
     a.id as id, a.title as title, a.content as content,
     a.latitude as latitude, a.longitude as longitude, a.public_map as publicMap,
     a.private_map as privateMap, a.member_id as writerId,
@@ -47,7 +38,6 @@
   </select>
   <resultMap id="ArticleDetails" type="ArticlePageDto">
     <id property="articleId" column="articleId"/>
-    <result property="articleLike" column="articleLike"/>
     <association property="articleDetails" javaType="ArticleDetailsDto">
       <id property="id" column="id"/>
       <result property="title" column="title"/>

--- a/backend/footprint/src/main/resources/mapper/commentLike/CommentLikeMapper.xml
+++ b/backend/footprint/src/main/resources/mapper/commentLike/CommentLikeMapper.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE mapper  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="foot.footprint.domain.commentLike.dao.CommentLikeRepository">
-  <select id="findCommentIdsILiked" resultType="Long">
-    SELECT c.id FROM comment c JOIN comment_like l ON c.id = l.comment_id
-    WHERE c.article_id = #{articleId} AND l.member_id=#{memberId}
-  </select>
   <insert id="saveCommentLike" parameterType="CommentLike" useGeneratedKeys="true" keyProperty="id">
     INSERT INTO comment_like (
     comment_id, member_id) VALUES (#{comment_id}, #{member_id})

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -167,15 +167,13 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         commentLikeRepository.saveCommentLike(commentLike3);
 
         //when
-        Optional<ArticlePageDto> dto = findArticleRepository.findArticleDetails(article.getId(),
-            member1.getId());
+        Optional<ArticlePageDto> dto = findArticleRepository.findArticleDetails(article.getId());
 
         //then
         assertThat(dto).isPresent();
         assertThat(dto.get().getArticleId()).isEqualTo(article.getId());
         assertThat(dto.get().getArticleDetails().getContent()).isEqualTo(article.getContent());
         assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
-        assertThat(dto.get().isArticleLike()).isTrue();
         assertThat(dto.get().getComments().size()).isEqualTo(2);
         assertThat(dto.get().getComments().get(0).getNickName()).isEqualTo(member2.getNick_name());
         assertThat(dto.get().getComments().get(0).getMemberId()).isEqualTo(member2.getId());
@@ -194,18 +192,15 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         assertThat(resultComment).isEqualTo(13);
 
         //when
-        Optional<ArticlePageDto> dto2 = findArticleRepository.findArticleDetails(article.getId(),
-            member1.getId());
+        Optional<ArticlePageDto> dto2 = findArticleRepository.findArticleDetails(article.getId());
 
         //then
         assertThat(dto2).isPresent();
         assertThat(dto2.get().getComments()).hasSize(10);
 
         //when & then : 로그인 하지 않았을 시
-        Optional<ArticlePageDto> dto3 = findArticleRepository.findArticleDetails(article.getId(),
-                null);
+        Optional<ArticlePageDto> dto3 = findArticleRepository.findArticleDetails(article.getId());
         assertThat(dto3).isPresent();
-        assertThat(dto3.get().isArticleLike()).isFalse();
     }
 
     private void saveArticle(double lat, double lng, boolean publicMap, boolean privateMap) {

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -246,7 +246,7 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         assertThat(detailsDto1.get().isArticleLike()).isTrue();
         assertThat(detailsDto2.get().isArticleLike()).isFalse();
         assertThat(detailsDto1.get().getCommentLikes()).hasSize(0);
-        assertThat(detailsDto2.get().getCommentLikes()).hasSize(1);
+        assertThat(detailsDto2.get().getCommentLikes()).hasSize(3);
     }
 
     private void saveArticle(double lat, double lng, boolean publicMap, boolean privateMap) {

--- a/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/article/FIndArticleRepositoryTest.java
@@ -6,6 +6,7 @@ import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.domain.LocationRange;
 import foot.footprint.domain.article.dto.articleDetails.ArticlePageDto;
 import foot.footprint.domain.article.dto.ArticleRangeRequest;
+import foot.footprint.domain.article.dto.articleDetails.ArticlePrivateDetailsDto;
 import foot.footprint.domain.articleLike.dao.ArticleLikeRepository;
 import foot.footprint.domain.articleLike.domain.ArticleLike;
 import foot.footprint.domain.comment.dao.CreateCommentRepository;
@@ -168,9 +169,14 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
 
         //when
         Optional<ArticlePageDto> dto = findArticleRepository.findArticleDetails(article.getId());
+        Optional<ArticlePrivateDetailsDto> detailsDto = findArticleRepository
+            .findArticlePrivateDetails(article.getId(), member1.getId());
 
         //then
+
         assertThat(dto).isPresent();
+        assertThat(detailsDto).isPresent();
+        assertThat(detailsDto.get().getCommentLikes()).hasSize(2);
         assertThat(dto.get().getArticleId()).isEqualTo(article.getId());
         assertThat(dto.get().getArticleDetails().getContent()).isEqualTo(article.getContent());
         assertThat(dto.get().getArticleDetails().getTotalLikes()).isEqualTo(2);
@@ -201,6 +207,46 @@ public class FIndArticleRepositoryTest extends RepositoryTest {
         //when & then : 로그인 하지 않았을 시
         Optional<ArticlePageDto> dto3 = findArticleRepository.findArticleDetails(article.getId());
         assertThat(dto3).isPresent();
+    }
+
+    @Test
+    public void findArticlePrivateDetails() {
+        //given
+        Member member1 = buildMember();
+        memberRepository.saveMember(member1);
+        Member member2 = buildMember();
+        memberRepository.saveMember(member2);
+        Article article1 = buildArticle(member1.getId());
+        createArticleRepository.saveArticle(article1);
+        Article article2 = buildArticle(member1.getId());
+        createArticleRepository.saveArticle(article2);
+        ArticleLike articleLike1 = buildArticleLike(member1.getId(), article1.getId());
+        articleLikeRepository.saveArticleLike(articleLike1);
+        Comment comment1 = buildComment(member1.getId(), article2.getId());
+        Comment comment2 = buildComment(member1.getId(), article2.getId());
+        Comment comment3 = buildComment(member1.getId(), article2.getId());
+        createCommentRepository.saveComment(comment1);
+        createCommentRepository.saveComment(comment2);
+        createCommentRepository.saveComment(comment3);
+        CommentLike commentLike1 = buildCommentLike(comment1.getId(), member1.getId());
+        CommentLike commentLike2 = buildCommentLike(comment2.getId(), member2.getId());
+        commentLikeRepository.saveCommentLike(commentLike1);
+        commentLikeRepository.saveCommentLike(commentLike2);
+
+        //when
+        Optional<ArticlePrivateDetailsDto> detailsDto1 = findArticleRepository
+            .findArticlePrivateDetails(article1.getId(), member1.getId());
+        Optional<ArticlePrivateDetailsDto> detailsDto2 = findArticleRepository
+            .findArticlePrivateDetails(article2.getId(), member1.getId());
+
+        //then
+        assertThat(detailsDto1.isPresent()).isTrue();
+        assertThat(detailsDto2.isPresent()).isTrue();
+        assertThat(detailsDto1.get().getArticleId()).isEqualTo(article1.getId());
+        assertThat(detailsDto1.get().isArticleLike()).isTrue();
+        assertThat(detailsDto2.get().isArticleLike()).isFalse();
+        assertThat(detailsDto1.get().getCommentLikes()).hasSize(0);
+        assertThat(detailsDto2.get().getCommentLikes()).hasSize(1);
     }
 
     private void saveArticle(double lat, double lng, boolean publicMap, boolean privateMap) {

--- a/backend/footprint/src/test/java/foot/footprint/repository/commentLike/CommentLIkeRepositoryTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/repository/commentLike/CommentLIkeRepositoryTest.java
@@ -47,42 +47,6 @@ public class CommentLIkeRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    public void findHasILiked() {
-        //given
-        // 2명의 유저
-        Member member = buildMember();
-        memberRepository.saveMember(member);
-        Member another = buildMember();
-        memberRepository.saveMember(another);
-        //게시글 생성
-        Article article = buildArticle(member.getId());
-        createArticleRepository.saveArticle(article);
-        //4개의 댓글, 3개는 member, 1개는 another
-        Comment comment1 = buildComment(member.getId(), article.getId());
-        createCommentRepository.saveComment(comment1);
-        Comment comment2 = buildComment(member.getId(), article.getId());
-        createCommentRepository.saveComment(comment2);
-        Comment comment3 = buildComment(member.getId(), article.getId());
-        createCommentRepository.saveComment(comment3);
-        Comment comment4 = buildComment(another.getId(), article.getId());
-        createCommentRepository.saveComment(comment4);
-        //3개의 좋아요, 2개는 member 1개는 another
-        CommentLike commentLike1 = buildCommentLike(comment1.getId(), member.getId());
-        commentLikeRepository.saveCommentLike(commentLike1);
-        CommentLike commentLike2 = buildCommentLike(comment2.getId(), another.getId());
-        commentLikeRepository.saveCommentLike(commentLike2);
-        CommentLike commentLike4 = buildCommentLike(comment4.getId(), member.getId());
-        commentLikeRepository.saveCommentLike(commentLike4);
-
-        //when
-        List<Long> commentLikes = commentLikeRepository.findCommentIdsILiked(article.getId(),
-            member.getId());
-
-        //then
-        assertThat(commentLikes).hasSize(2);
-    }
-
-    @Test
     public void deleteCommentLike() {
         //given
         Member member = buildMember();

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
@@ -10,6 +10,8 @@ import foot.footprint.domain.article.domain.Article;
 import foot.footprint.domain.article.dto.articleDetails.ArticleDetailsDto;
 import foot.footprint.domain.article.dto.articleDetails.ArticlePageDto;
 import foot.footprint.domain.article.dto.articleDetails.ArticlePageResponse;
+import foot.footprint.domain.article.dto.articleDetails.ArticlePrivateDetailsDto;
+import foot.footprint.domain.article.dto.articleDetails.MyCommentLikesInArticle;
 import foot.footprint.domain.comment.dto.CommentsDto;
 import foot.footprint.domain.commentLike.dao.CommentLikeRepository;
 import foot.footprint.global.security.user.CustomUserDetails;
@@ -54,13 +56,16 @@ public class FindArticleDetailsServiceTest {
             new Date(), 0L);
         List<CommentsDto> responses = new ArrayList<>();
         responses.add(response);
-        ArticlePageDto dto = new ArticlePageDto(articleId, details, true, responses);
-        given(findArticleRepository.findArticleDetails(any(), any())).willReturn(Optional.of(dto));
-        //댓글 좋아요 리스트 리턴
-        List<Long> commentLikes = new ArrayList<>();
-        commentLikes.add(1L);
-        given(commentLikeRepository.findCommentIdsILiked(any(), any())).willReturn(
-            new ArrayList<>(commentLikes));
+        ArticlePageDto dto = new ArticlePageDto(articleId, details, responses);
+        given(findArticleRepository.findArticleDetails(any())).willReturn(Optional.of(dto));
+        //댓글 좋아요 리스트 및 내 좋아요 리턴
+
+        List<MyCommentLikesInArticle> myComments = new ArrayList<>();
+        myComments.add(new MyCommentLikesInArticle(1L));
+        ArticlePrivateDetailsDto privateDto = new ArticlePrivateDetailsDto(articleId, true,
+            myComments);
+        given(findArticleRepository.findArticlePrivateDetails(any(), any())).willReturn(
+            Optional.of(privateDto));
         //objectSerializer - 캐시 데이터는 없다고 가정하고 리턴
         given(objectSerializer.getData(any(), any())).willReturn(Optional.empty());
     }
@@ -86,7 +91,8 @@ public class FindArticleDetailsServiceTest {
         assertThat(response.getMyMemberId()).isEqualTo(memberId);
 
         //when 유저 정보가 null(로그인하지 않는 상태)
-        ArticlePageResponse response2 = findPublicArticleDetailsService.findDetails(articleId, null);
+        ArticlePageResponse response2 = findPublicArticleDetailsService.findDetails(articleId,
+            null);
 
         //then
         assertThat(response2.getArticleDetails().getId()).isEqualTo(articleId);

--- a/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
+++ b/backend/footprint/src/test/java/foot/footprint/service/article/FindArticleDetailsServiceTest.java
@@ -61,7 +61,7 @@ public class FindArticleDetailsServiceTest {
         //댓글 좋아요 리스트 및 내 좋아요 리턴
 
         List<MyCommentLikesInArticle> myComments = new ArrayList<>();
-        myComments.add(new MyCommentLikesInArticle(1L));
+        myComments.add(new MyCommentLikesInArticle(1L, memberId));
         ArticlePrivateDetailsDto privateDto = new ArticlePrivateDetailsDto(articleId, true,
             myComments);
         given(findArticleRepository.findArticlePrivateDetails(any(), any())).willReturn(


### PR DESCRIPTION
resolved: #112 

현재 프로젝트에서는 레디스 관련 문제가 하나 있다.
게시 글 조회 시 DB로부터 데이터를 가져오는 메서드는 두 개로 통합되어 었다.
이는 4개 였던 메서드를 2개로 통합하여 속도 향상을 이룰 수 있었던 기록이다.
하지만 레디스를 도입하면서 게시글 조회 시 레디스에 데이터를 저장하는데, 통합된 메서드는 사용자 개개인의 정보 또한 포함된다.
그렇기에 레디스에는 사용자 별로 데이터가 존재할 수 밖에 없다. 이는 공간적 측면에서 낭비일 수 밖에 없다고 판단하였다.
속도와 공간의 트레이드 오프가 생성 된 셈이다.

이를 해결하기 위한 절충안으로 통합된 메서드를 이전과 다른 방식으로 분리하여 공간의 문제를 해결하고, 시간의 문제를 덜 발생시키는 것이 목표이다.

1. FindArticleRepository#findArticleDetails 시 개인 정보를 포함하지 않는 정보만을 반환하도록 수정
2. FindArticleRepository#findArticlePrivateDetails 을 구현하여 개인 정보를 반황하도록 함. 비 로그인 시 findArticleDetails 만을 호출하여 개인 정보가 필요 없는 내용만을 반환토록 하고, 이 정보를 레디스에 저장.
로그이 시 findArticlePrivateDetails를 같이 호출하여 게시글 좋아요, 댓글 좋아요 정보를 얻어옴. 이 메서드를 통해 얻은 정보는 레디스에 저장하지 않음.
즉, 두개의 메서드가 있으며 비 로그인 시 한 개의 메서드만을 실시하고, 레디스에 데이터가 있으면 DB를 접근하지 않음.
로그인 시 두 개의 메서드를 실행하는데 레디스에 데이터가 있으면 한 메서드는 실행하지 않고 레디스에서 데이터를 가져오고 남은 한 메서드 실행을 통한 1번의 DB 접근만이 있음.

이전에는 비 로그인 시 레디스 실행x 한번의 메서드 실행하여 DB 1번 접근
로그인 시 2번의 메서드 실행하여 2번 DB 접근, 레디스에 데이터가 있을 시 0번의 DB 접근

즉, 변화된 것은 로그인 시 레디스에 데이터가 있을시에도 DB를 1번 접근하는 점과 비 로그인 시 레디스에 데이터가 있으면 DB에 접근을 하지 않는 다는 것이다. 

이전과 비교해서 어떤 것이 더 좋아졌다고는 명확히 언급을 할 순 없지만, 레디스 내 조회자 정보를 포함한 게시글 데이터로 공간을 낭비하는 문제는 해결하였다.


3. 게시글 좋아요 
4. 댓글 추가
5. 게시글 수정
6. 댓글 수정
7. 댓글 좋아요 변경
8. 댓글 삭제
=>redis에 개인 정보가 들어가지 않게 ObjectSerializer, ArticleUpdatePart, ArticlePageDto 등 내부 메서드 수정

